### PR TITLE
Checkbox: bring back label after merge conflict

### DIFF
--- a/component-library/component-lib/src/lib/checkbox/checkbox.component.html
+++ b/component-library/component-lib/src/lib/checkbox/checkbox.component.html
@@ -1,31 +1,52 @@
 <form class="checkbox-container" [formGroup]="config.formGroup">
-  <p *ngIf="config?.desc" class="check-desc" [ngClass]="config.size">{{(config.desc || '') | translate}}</p>
-  <p *ngIf="config?.helpText" class="check-hint" [ngClass]="config.size">{{(config.helpText || '') | translate}}</p>
-  <div class="checkbox-layout" [ngClass]="{ error: getErrorState() }">
-    <div class="checkbox">
-      <input id="{{config.id}}" class="check"
-        [ngClass]="{ mixed: config?.mixed, focus: !config.disableFocus, error: getErrorState()}"
-        [attr.size]="config.size" type="checkbox"
-        [formControlName]="config.id" />
-      <span class="checkmark"></span>
-    </div>
-    <label class="label" for="{{config.id}}" 
-      [attr.aria-label]="
-        config.formGroup.get(config.id)?.invalid && config.formGroup.get(config.id)?.dirty 
-        ? (config.inlineLabel || '' | translate) + ' ' +
-          (config.helpText || '' | translate) + ' ' + 
-          ('Error: ' + standAloneFunctions.getErrorAria(config.formGroup, config.id, (config.errorMessages || []))) 
-        :
-          (config.inlineLabel || '' | translate) + ' ' + (config.helpText || '' | translate)
-      " 
-      [ngClass]="{'disabled-label': isDisabled, 'small': config.size === 'small' }">{{config.inlineLabel || '' }}
-    </label>
-  </div>
-  <div *ngIf="getErrorState()" class="check-error" [ngClass]="{'small': config.size === 'small' }">
-    <ng-container *ngFor="let error of config.errorMessages; index as i">
-      <div *ngIf="config.formGroup.get(config.id)?.errors?.[error.key]">
-        <lib-error [id]="config.id + '_error'" [errorLOV]="error.errorLOV" [icon]="config?.errorIcon" aria-live="polite"></lib-error>
+  <div class="checkbox-container" [ngClass]="config.size">
+    <label *ngIf="config.label" class="checkbox-label"
+       [attr.aria-label]="
+          config.formGroup.get(config.id)?.invalid && config.formGroup.get(config.id)?.dirty
+          ? (config.label || '' | translate) + ' ' +
+            (config.desc || '' | translate) + ' ' + ('INPUT.ERROR' | translate) + ' ' +
+            (config?.helpText || '' | translate)
+          : (config.label || '' | translate)  + ' ' +
+            (config.desc || '' | translate) + ' ' +
+            (config?.helpText || '' | translate)
+       "
+    >
+      <div class="required-field-container" *ngIf="config.required">
+        <lib-icon [class]="'fa-regular fa-asterisk required-star'"></lib-icon>
+        {{(config.label || '') | translate}}
       </div>
-    </ng-container>
+      <div *ngIf="!config.required">
+        {{(config.label || '') | translate}}
+      </div>
+    </label>
+    <p *ngIf="config?.desc" class="check-desc" [ngClass]="config.size">{{(config.desc || '') | translate}}</p>
+    <p *ngIf="config?.helpText" class="check-hint" [ngClass]="config.size">{{(config.helpText || '') | translate}}</p>
+    <div class="checkbox-layout" [ngClass]="{ error: getErrorState() }">
+      <div class="checkbox">
+        <input id="{{config.id}}" class="check"
+          [ngClass]="{ mixed: config?.mixed, focus: !config.disableFocus, error: getErrorState()}"
+          [attr.size]="config.size" type="checkbox"
+          [formControlName]="config.id" />
+        <span class="checkmark"></span>
+      </div>
+      <label class="label" for="{{config.id}}"
+        [attr.aria-label]="
+          config.formGroup.get(config.id)?.invalid && config.formGroup.get(config.id)?.dirty
+          ? (config.inlineLabel || '' | translate) + ' ' +
+            (config.helpText || '' | translate) + ' ' +
+            ('Error: ' + standAloneFunctions.getErrorAria(config.formGroup, config.id, (config.errorMessages || [])))
+          :
+            (config.inlineLabel || '' | translate) + ' ' + (config.helpText || '' | translate)
+        "
+        [ngClass]="{'disabled-label': isDisabled, 'small': config.size === 'small' }">{{config.inlineLabel || '' }}
+      </label>
+    </div>
+    <div *ngIf="getErrorState()" class="check-error" [ngClass]="{'small': config.size === 'small' }">
+      <ng-container *ngFor="let error of config.errorMessages; index as i">
+        <div *ngIf="config.formGroup.get(config.id)?.errors?.[error.key]">
+          <lib-error [id]="config.id + '_error'" [errorLOV]="error.errorLOV" [icon]="config?.errorIcon" aria-live="polite"></lib-error>
+        </div>
+      </ng-container>
+    </div>
   </div>
 </form>


### PR DESCRIPTION
A recent merge did not properly resolve conflict in `component-library/component-lib/src/lib/checkbox/checkbox.component.html`, brought back changes from https://github.com/IRCC-ca/ds-sdc-dev/pull/59/files#diff-d1c38f8d5e9a6e5547376f73875594d1e165d5749bd822073d572cb049114df3