### PR TITLE
Bug/errors

### DIFF
--- a/component-library/component-lib/src/lib/checkbox/checkbox.component.html
+++ b/component-library/component-lib/src/lib/checkbox/checkbox.component.html
@@ -22,7 +22,7 @@
     <div class="checkbox-layout" [ngClass]="{ error: getErrorState() }">
       <div class="checkbox">
         <input id="{{config.id}}" class="check"
-          [ngClass]="{ mixed: config?.mixed, focus: !config.disableFocus, error: getErrorState()}"
+          [ngClass]="{ mixed: config.mixed, focus: !config.disableFocus, error: getErrorState()}"
           [attr.size]="config.size" type="checkbox" [formControlName]="config.id" />
         <span class="checkmark"></span>
       </div>

--- a/component-library/component-lib/src/lib/checkbox/checkbox.component.html
+++ b/component-library/component-lib/src/lib/checkbox/checkbox.component.html
@@ -1,14 +1,5 @@
 <form class="checkbox-container" [formGroup]="config.formGroup">
   <div class="checkbox-container" [ngClass]="config.size">
-    <!-- <label *ngIf="config.label" class="checkbox-label" [attr.aria-label]="
-          config.formGroup.get(config.id)?.invalid && config.formGroup.get(config.id)?.dirty
-          ? (config.label || '' | translate) + ' ' +
-            (config.desc || '' | translate) + ' ' + ('INPUT.ERROR' | translate) + ' ' +
-            (config?.helpText || '' | translate)
-          : (config.label || '' | translate)  + ' ' +
-            (config.desc || '' | translate) + ' ' +
-            (config?.helpText || '' | translate)
-       "> -->
        <label *ngIf="config.label"
        [attr.aria-label]="
          config.formGroup.get(config.id)?.invalid && config.formGroup.get(config.id)?.dirty
@@ -45,10 +36,10 @@
         " [ngClass]="{'disabled-label': isDisabled, 'small': config.size === 'small' }">{{config.inlineLabel || '' }}
       </label>
     </div>
-    <div *ngIf="getErrorState()" class="check-error" [ngClass]="{'small': config.size === 'small' }">
-      <ng-container *ngFor="let errors of config.errorMessages; let i = index">
+    <div *ngIf="(config.formGroup.get(config.id)?.touched) && config.formGroup.get(config.id)?.invalid" class="check-error" [ngClass]="{'small': config.size === 'small' }">
+      <ng-container *ngFor="let errors of errorIds; let i = index">
         <div *ngIf="config.formGroup.get(config.id)?.errors?.[errors.key]" class="radio-errors">
-          <lib-error [id]="config.id + '_error' + i" [errorLOV]="errors.errorLOV" aria-live="polite"></lib-error>
+          <lib-error [id]="errors.id" [errorLOV]="errors.errorLOV" aria-live="polite"></lib-error>
         </div>
       </ng-container>
     </div>

--- a/component-library/component-lib/src/lib/checkbox/checkbox.component.ts
+++ b/component-library/component-lib/src/lib/checkbox/checkbox.component.ts
@@ -3,7 +3,7 @@ import {ControlValueAccessor, FormGroup, NG_VALUE_ACCESSOR} from '@angular/forms
 import {DSSizes} from "../../shared/constants/jl-components/jl-components.constants/jl-components.constants";
 import {IErrorIconConfig} from "../error/error.component";
 import {IErrorPairs} from "../../shared/interfaces/component-configs";
-import { StandAloneFunctions } from '../../shared/functions/stand-alone.functions';
+import { IErrorIDs, StandAloneFunctions } from '../../shared/functions/stand-alone.functions';
 
 export interface ICheckBoxComponentConfig {
   formGroup: FormGroup;
@@ -47,6 +47,7 @@ export class CheckboxComponent implements ControlValueAccessor, OnInit {
   @Input() id = '';
 
   isDisabled = false;
+  errorIds: IErrorIDs[] = [];
 
   constructor(public standAloneFunctions: StandAloneFunctions) { }
 
@@ -79,6 +80,10 @@ export class CheckboxComponent implements ControlValueAccessor, OnInit {
 
     if (this.formGroup !== this.formGroupEmpty) {
       this.config.formGroup = this.formGroup;
+    }
+
+    if (this.config.errorMessages) {
+      this.errorIds = this.standAloneFunctions.getErrorIds(this.config.formGroup, this.config.id, this.config.errorMessages)
     }
   }
 

--- a/component-library/component-lib/src/lib/dropdown-input/dropdown-input.component.html
+++ b/component-library/component-lib/src/lib/dropdown-input/dropdown-input.component.html
@@ -27,10 +27,10 @@
       </select>
       <i class="fa-thin fa-chevron-down custom-chevron"></i>
     </div>
-    <ng-container *ngIf="config.formGroup.get(config.id)?.touched && config.formGroup.get(config.id)?.invalid">
-      <ng-container *ngFor="let errors of config.errorMessages; let i = index">
-        <div *ngIf="config.formGroup.get(config.id)?.errors?.[errors.key]">
-          <lib-error [id]="config.id + '_error' + i" [errorLOV]="errors.errorLOV" [size]="config?.size" aria-live="polite"></lib-error>
+    <ng-container *ngIf="(config.formGroup.get(config.id)?.touched) && config.formGroup.get(config.id)?.invalid">
+      <ng-container *ngFor="let errors of errorIds; let i = index">
+        <div *ngIf="config.formGroup.get(config.id)?.errors?.[errors.key]" class="radio-errors">
+          <lib-error [id]="errors.id" [errorLOV]="errors.errorLOV" aria-live="polite"></lib-error>
         </div>
       </ng-container>
     </ng-container>

--- a/component-library/component-lib/src/lib/dropdown-input/dropdown-input.component.ts
+++ b/component-library/component-lib/src/lib/dropdown-input/dropdown-input.component.ts
@@ -2,7 +2,7 @@ import { Component, forwardRef, Input, OnInit } from '@angular/core';
 import { ControlValueAccessor, FormControl, FormGroup, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { DSSizes } from '../../shared/constants/jl-components/jl-components.constants/jl-components.constants';
 import { IErrorPairs } from '../../shared/interfaces/component-configs';
-import { StandAloneFunctions } from '../../shared/functions/stand-alone.functions';
+import { IErrorIDs, StandAloneFunctions } from '../../shared/functions/stand-alone.functions';
 
 export declare enum DropdownType {
   secondary = "secondary",
@@ -38,8 +38,9 @@ export interface IDropdownInputOptionsConfig {
     }
   ]
 })
-export class DropdownInputComponent implements ControlValueAccessor {
+export class DropdownInputComponent implements ControlValueAccessor, OnInit {
   touched = false;
+  errorIds: IErrorIDs[] = [];
 
   @Input() config: IDropdownInputConfig = {
     id: '',
@@ -65,6 +66,12 @@ export class DropdownInputComponent implements ControlValueAccessor {
     if (!this.touched) {
       this.onTouched();
       this.touched = true;
+    }
+  }
+
+  ngOnInit() {
+    if (this.config.errorMessages) {
+      this.errorIds = this.standAloneFunctions.getErrorIds(this.config.formGroup, this.config.id, this.config.errorMessages)
     }
   }
 }

--- a/component-library/component-lib/src/lib/input/input.component.html
+++ b/component-library/component-lib/src/lib/input/input.component.html
@@ -49,10 +49,10 @@
           </button>
         </div>
       </div>
-      <div *ngIf="getErrorState()" class="check-error">
-        <ng-container *ngFor="let errors of config.errorMessages; let i = index">
+      <div *ngIf="(config.formGroup.get(config.id)?.touched) && config.formGroup.get(config.id)?.invalid" class="check-error">
+        <ng-container *ngFor="let errors of errorIds; let i = index">
           <div *ngIf="config.formGroup.get(config.id)?.errors?.[errors.key]" class="radio-errors">
-            <lib-error [id]="config.id + '_error' + i" [errorLOV]="errors.errorLOV" aria-live="polite"></lib-error>
+            <lib-error [id]="errors.id" [errorLOV]="errors.errorLOV" aria-live="polite"></lib-error>
           </div>
         </ng-container>
       </div>

--- a/component-library/component-lib/src/lib/input/input.component.ts
+++ b/component-library/component-lib/src/lib/input/input.component.ts
@@ -8,7 +8,7 @@ import { ControlValueAccessor, FormGroup, NG_VALUE_ACCESSOR } from '@angular/for
 import { DSSizes } from '../../shared/constants/jl-components/jl-components.constants/jl-components.constants';
 import {IErrorPairs} from "../../shared/interfaces/component-configs";
 import {IErrorIconConfig} from "../error/error.component";
-import { StandAloneFunctions } from '../../shared/functions/stand-alone.functions';
+import { IErrorIDs, StandAloneFunctions } from '../../shared/functions/stand-alone.functions';
 
 export interface IInputComponentConfig {
   label?: string;
@@ -54,6 +54,7 @@ export class InputComponent implements ControlValueAccessor, OnInit {
   disabled = false;
   focusState = false;
   showPassword = false;
+  errorIds: IErrorIDs[] = []
 
   constructor(public standAloneFunctions: StandAloneFunctions) { }
 
@@ -80,6 +81,9 @@ export class InputComponent implements ControlValueAccessor, OnInit {
         this.disabled = false;
       }
     });
+    if (this.config.errorMessages) {
+      this.errorIds = this.standAloneFunctions.getErrorIds(this.config.formGroup, this.config.id, this.config.errorMessages)
+    }
   }
 
   public focusInput(focusValue: boolean): void {

--- a/component-library/component-lib/src/lib/radio-input/radio-input.component.html
+++ b/component-library/component-lib/src/lib/radio-input/radio-input.component.html
@@ -33,9 +33,9 @@
     </div>
   </div>
   <ng-container *ngIf="(config.formGroup.get(config.id)?.touched) && config.formGroup.get(config.id)?.invalid">
-    <ng-container *ngFor="let errors of config.errorMessages; let i = index">
+    <ng-container *ngFor="let errors of errorIds; let i = index">
       <div *ngIf="config.formGroup.get(config.id)?.errors?.[errors.key]" class="radio-errors">
-        <lib-error [id]="config.id + '_error' + i" [errorLOV]="errors.errorLOV" aria-live="polite"></lib-error>
+        <lib-error [id]="errors.id" [errorLOV]="errors.errorLOV" aria-live="polite"></lib-error>
       </div>
     </ng-container>
   </ng-container>

--- a/component-library/component-lib/src/lib/radio-input/radio-input.component.ts
+++ b/component-library/component-lib/src/lib/radio-input/radio-input.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/forms';
 import { IErrorPairs } from '../../shared/interfaces/component-configs';
 import { DSSizes } from '../../shared/constants/jl-components/jl-components.constants/jl-components.constants';
-import { StandAloneFunctions } from '../../shared/functions/stand-alone.functions';
+import { IErrorIDs, StandAloneFunctions } from '../../shared/functions/stand-alone.functions';
 
 export interface IRadioInputComponentConfig {
   id: string;
@@ -34,6 +34,8 @@ export interface IRadioInputOption {
   error?: true;
 }
 
+
+
 @Component({
   selector: 'lib-radio-input',
   templateUrl: './radio-input.component.html',
@@ -48,6 +50,7 @@ export interface IRadioInputOption {
 export class RadioInputComponent implements OnInit, ControlValueAccessor {
   formGroupEmpty = new FormGroup({});
   touched = false;
+  errorIds: IErrorIDs[] = [];
 
   @Input() config: IRadioInputComponentConfig = {
     id: '',
@@ -80,7 +83,9 @@ export class RadioInputComponent implements OnInit, ControlValueAccessor {
   ngOnInit() {
     if (this.id !== '') this.config.id = this.id;
     if (this.formGroup !== this.formGroupEmpty) this.config.formGroup = this.formGroup;
-
+    if (this.config.errorMessages) {
+      this.errorIds = this.standAloneFunctions.getErrorIds(this.config.formGroup, this.config.id, this.config.errorMessages)
+    }
   }
 
 

--- a/component-library/component-lib/src/shared/functions/stand-alone.functions.ts
+++ b/component-library/component-lib/src/shared/functions/stand-alone.functions.ts
@@ -3,11 +3,17 @@ import { FormGroup } from "@angular/forms";
 import { TranslateService } from "@ngx-translate/core";
 import { IErrorPairs } from "../interfaces/component-configs";
 
+export interface IErrorIDs {
+    id?: string;
+    key: string;
+    errorLOV: string;
+}
+
 @Injectable({
     providedIn: 'root'
 })
 export class StandAloneFunctions {
-    constructor(private translate: TranslateService) {}
+    constructor(private translate: TranslateService) { }
 
     getErrorAria(formGroup: FormGroup, id: string, errorMessages: IErrorPairs[]) {
         let returnError = '';
@@ -20,5 +26,22 @@ export class StandAloneFunctions {
             });
         }
         return returnError;
+    }
+
+    getErrorIds(formGroup: FormGroup, id: string, errorMessages: IErrorPairs[]) {
+        let errorIds: IErrorIDs[] = [];
+        errorMessages?.forEach(message => {
+            errorIds.push({ key: message.key, errorLOV: message.errorLOV });
+        });
+        formGroup.get(id)?.statusChanges.subscribe(() => {
+            let i = 0;
+            errorIds.forEach(error => {
+                if (formGroup.get(id)?.errors?.[error.key]) {
+                    error.id = (id + '_error' + i);
+                    i++;
+                }
+            });
+        });
+        return errorIds;
     }
 }

--- a/component-library/component-lib/src/shared/functions/stand-alone.functions.ts
+++ b/component-library/component-lib/src/shared/functions/stand-alone.functions.ts
@@ -28,6 +28,15 @@ export class StandAloneFunctions {
         return returnError;
     }
 
+    /**
+     * When run, returns an IErrorIds object. It generates IDs based on the errorMessages object
+     * and which errors are currently in effect, thereby ensuring that the first element is given 
+     * an id ending in _error0
+     * @param formGroup 
+     * @param id of the parent (input) component
+     * @param errorMessages: IErrorPairs[]
+     * @returns errorIds: IErrorIDs[]
+     */
     getErrorIds(formGroup: FormGroup, id: string, errorMessages: IErrorPairs[]) {
         let errorIds: IErrorIDs[] = [];
         errorMessages?.forEach(message => {


### PR DESCRIPTION
Changes how the ids for error display are assigned. 

Function (getErrorIds) is moved into StandAloneFunctions in shared, and each input component runs it onInit(). This returns an observable that is updated whenever there is change to the validity of the form (formControl.statusChage()), thereby updating a new object in the component called errorIds of type IErrorIds. IErrorIds is made up of an optional id, a key, and errorLOV.