### PR TITLE
Indicator: misc bug fixes

### DIFF
--- a/component-library/src/app/gallery/QA/michael/michael.component.ts
+++ b/component-library/src/app/gallery/QA/michael/michael.component.ts
@@ -508,7 +508,7 @@ export class MichaelComponent implements OnInit {
         updatedConfig = {...updatedConfig, [param] : x[param]}
         if (updatedConfig?.type === 'number') {
           updatedConfig = {...updatedConfig,
-            'label' : Number(updatedConfig?.label)
+            'label' : isNaN(Number(updatedConfig?.label)) ? 1 : Number(updatedConfig?.label)
           }
         }
       }

--- a/core-library/component-styling/indicator/_indicator.scss
+++ b/core-library/component-styling/indicator/_indicator.scss
@@ -68,7 +68,7 @@ $color: grey,red,orange,blue,green,purple,teal,navy;
     padding: 4px 8px;
     border-radius: 15px;
 
-    @include typography.fontSet(body, 2);
+    @include typography.fontSet(body, 3);
 
     &.rounded {
       padding: 2px 8px;
@@ -87,7 +87,7 @@ $color: grey,red,orange,blue,green,purple,teal,navy;
       min-width: 18px;
     }
 
-    @include typography.fontSet(body, 2);
+    @include typography.fontSet(body, 3);
 
     &.num-lg {
       padding: 4px 8px;

--- a/core-library/component-styling/indicator/_indicator.scss
+++ b/core-library/component-styling/indicator/_indicator.scss
@@ -207,6 +207,11 @@ $color: grey,red,orange,blue,green,purple,teal,navy;
       display: block;
       overflow: hidden;
     }
+
+    // Force hiding icon when change from text to number
+    > svg {
+      display: none;
+    }
   }
 
   @include size.selector(small) {

--- a/core-library/component-styling/indicator/_indicator.scss
+++ b/core-library/component-styling/indicator/_indicator.scss
@@ -35,6 +35,7 @@ $color: grey,red,orange,blue,green,purple,teal,navy;
 
     &.rounded {
       min-width: 8px;
+      border-radius: 50%;
     }
 
     > svg {
@@ -43,7 +44,7 @@ $color: grey,red,orange,blue,green,purple,teal,navy;
   }
 
   .number {
-    padding: 6px 9px;
+    padding: 2px 5px;
 
     > span {
       min-width: 14px;
@@ -71,8 +72,9 @@ $color: grey,red,orange,blue,green,purple,teal,navy;
     @include typography.fontSet(body, 3);
 
     &.rounded {
-      padding: 2px 8px;
+      padding: 4px 8px;
       min-width: 12px;
+      border-radius: 50%;
     }
 
     > svg {
@@ -81,7 +83,7 @@ $color: grey,red,orange,blue,green,purple,teal,navy;
   }
 
   .number {
-    padding: 7px 10px;
+    padding: 4px 5px;
 
     > span {
       min-width: 18px;
@@ -189,6 +191,7 @@ $color: grey,red,orange,blue,green,purple,teal,navy;
       display: block;
       overflow: hidden;
       white-space: nowrap;
+      width: 100%;
 
       &.abbr {
         text-overflow: ellipsis;

--- a/core-library/component-styling/indicator/_indicator.scss
+++ b/core-library/component-styling/indicator/_indicator.scss
@@ -101,27 +101,31 @@ $color: grey,red,orange,blue,green,purple,teal,navy;
   }
 }
 
-@mixin coloration($palette, $type){
+@mixin coloration($palette, $type) {
   @if $type == validation {
-    &.strong{
-      &.#{$palette}{
+    &.strong {
+      &.#{$palette} {
         background: var(--#{$palette}-background);
       }
     }
-    &.weak{
-      &.#{$palette}{
+
+    &.weak {
+      &.#{$palette} {
         background: var(--#{$palette}-background-weak);
         color: var(--#{$palette}-text);
       }
     }
-  } @if $type == colors {
-    &.strong{
-      &.#{$palette}{
+  }
+
+  @if $type == colors {
+    &.strong {
+      &.#{$palette} {
         background: var(--#{$palette}-category-background);
       }
     }
-    &.weak{
-      &.#{$palette}{
+
+    &.weak {
+      &.#{$palette} {
         background: var(--#{$palette}-category-background-weak);
         color: var(--#{$palette}-category-text);
       }
@@ -132,16 +136,18 @@ $color: grey,red,orange,blue,green,purple,teal,navy;
 @mixin layout {
   display: inline-block;
 
-  .text{
+  .text {
     @each $palette in $status {
       @include coloration($palette, validation);
     }
+
     @each $palette in $color {
       @include coloration($palette, colors);
     }
   }
 
-  .number, .dot{
+  .number,
+  .dot {
     @each $palette in $status {
       @include coloration($palette, validation);
     }


### PR DESCRIPTION
- ensure text label is centre at all time
- Large number indicator size should be 28 x 28px
Small number indicator size should be 24 x 24px

- When user has selected number indicator but changes it to text, the indicator should automatically update to the default text indicator and vice versa
- Number indicator should not have icon variable
- Large size use body 3 text for all