### PR TITLE
Breadcrumb: Space between separators and items

### DIFF
--- a/core-library/component-styling/breadcrumb/_breadcrumb.scss
+++ b/core-library/component-styling/breadcrumb/_breadcrumb.scss
@@ -55,7 +55,7 @@
 
 @mixin size-lg {
   ircc-cl-lib-breadcrumb-link {
-    margin-right: 8px;
+    margin-right: 4px;
 
     a,
     ircc-cl-lib-button .text {


### PR DESCRIPTION
Should be 4px padding on separators
Should be 12px from the breadcrumb item (currently there is 8px margin and 8px padding totalling 16px instead of 12)