### PR TITLE
Indicator: correct color

### DIFF
--- a/core-library/tokens/global/_categories.scss
+++ b/core-library/tokens/global/_categories.scss
@@ -16,7 +16,11 @@
 @mixin tokens($palette) {
     @include theme.light() {
         --#{$palette}-category-background: #{color.mix-token($palette, 700)};
-        --#{$palette}-category-background-weak: #{color.mix-token($palette, 100)};
+        @if ($palette == grey) {
+            --#{$palette}-category-background-weak: #{color.mix-token($palette, 200)};
+        } @else {
+            --#{$palette}-category-background-weak: #{color.mix-token($palette, 100)};
+        }
         --#{$palette}-category-text: #{color.mix-token($palette, 900)};
         --#{$palette}-category-text-weak: #{color.mix-token(neutral, 100)};
     }


### PR DESCRIPTION
grey weak - Hsl value corrected to 240 11 96 as per Figma.

red-weak, green weak, purple weak, navy-weak are already same as HSL value.