### PR TITLE
Input documentation style fix

### DIFF
--- a/component-library/src/app/pages/input-documentation/input-documentation.component.html
+++ b/component-library/src/app/pages/input-documentation/input-documentation.component.html
@@ -171,7 +171,7 @@
       {{ 'Input.MaxMinWidthHeading' | translate }}
     </h5>
     <div class="row">
-      <div>
+      <div [style.max-width]="'100%'">
         <img
           src="assets/img/input-content/input-max-width.png"
           alt="{{ 'Input.MaxMinWidthImgAlt' | translate }}"

--- a/component-library/src/app/pages/input-documentation/input-documentation.component.scss
+++ b/component-library/src/app/pages/input-documentation/input-documentation.component.scss
@@ -196,11 +196,11 @@ span {
 }
 
 .left-column {
-  margin-right: 12px;
+  padding-right: 12px;
 }
 
 .right-column {
-  margin-left: 12px;
+  padding-left: 12px;
 }
 
 .code-viewer {


### PR DESCRIPTION
Before
![FireShot Capture 068 - component-library - d1whfh0luwluq8 cloudfront net](https://github.com/IRCC-ca/ds-sdc-dev/assets/111757720/b600cee0-125b-4503-9522-4925d041873d)

After
![FireShot Capture 069 - component-library - localhost](https://github.com/IRCC-ca/ds-sdc-dev/assets/111757720/c0cdbafd-9a21-47ef-a51d-c7d1f4a0ce07)
