### PR TITLE
Changed number of CTA allowed at a time for banner

### DIFF
--- a/component-library/src/app/pages/banner-documentation/banner-doc-code.component.ts
+++ b/component-library/src/app/pages/banner-documentation/banner-doc-code.component.ts
@@ -17,6 +17,8 @@ import {
   stringify
 } from '@app/components/code-viewer/code-viewer.component';
 
+const NUMBER_OF_CTA_ALLOWED : number = 3;
+
 @Component({
   selector: 'app-banner-doc-code',
   templateUrl: './banner-doc-code.component.html',
@@ -25,7 +27,7 @@ import {
 export class BannerDocCodeComponent implements OnInit {
   @ViewChild('banner', { static: false }) banner!: ElementRef;
   altLangLink = 'bannerDocumentation';
-
+  
   constructor(
     private translate: TranslateService,
     private lang: LangSwitchService
@@ -349,10 +351,10 @@ export class BannerDocCodeComponent implements OnInit {
   }
 
   /**
-   * Disables/Enables button/link radios (Max 2 allowed on the banner at a time)
+   * Disables/Enables button/link radios (Max 3 allowed on the banner at a time)
    */
   checkCurrentButtonCounter() {
-    if (this.currentButtonSet.size >= 2) {
+    if (this.currentButtonSet.size >= NUMBER_OF_CTA_ALLOWED) {
       this.buttonSetWithAllOptions.forEach((btn) => {
         if (!this.currentButtonSet.has(btn)) {
           this.disableRadio(btn);


### PR DESCRIPTION
**Why are these changes introduced?**
* Changes introduced after QA mentioned the issue

**What is this pull request doing?**
* According to design a banner can have a maximum of 3 CTA, previously we had that set to 2 CTA. Changed that to 3 to match design.

**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)
* File names and hierarchies are in keeping with our norms
* Interfaces are named correctly
ngOnInit and constructor is removed when not used 
':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?



**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.