### PR TITLE
Bug-Fix: Changed copy ulr to use Plain button instead of <a>

### DIFF
--- a/component-library/src/app/components/title-slug-url/title-slug-url.component.html
+++ b/component-library/src/app/components/title-slug-url/title-slug-url.component.html
@@ -1,23 +1,27 @@
-<h1
-  *ngIf="config.heading === 'h1'"
-  id="{{ config.title | translate | SlugifyPipe }}"
->
-  <strong>{{ config.title | translate }}</strong>
-</h1>
-<h2
-  *ngIf="config.heading !== 'h1'"
-  [ngClass]="'h3'"
-  id="{{ config.title | translate | SlugifyPipe }}"
->
-  <strong>{{ config.title | translate }}</strong>
-</h2>
-<a
-  [className]="config.anchorType"
-  routerLink="{{ windowPathname }}"
-  fragment="{{ config.title | translate | SlugifyPipe }}"
-  cdkCopyToClipboard="{{ windowOrigin }}{{ windowPathname }}#{{
-    config.title | translate | SlugifyPipe
-  }}"
->
-  {{ 'Buttons.CopyURL' | translate }}
-</a>
+<div class="title-slug-wrapper {{ config.heading }}-heading-type">
+  <h1
+    *ngIf="config.heading === 'h1'"
+    id="{{ config.title | translate | SlugifyPipe }}"
+  >
+    <strong>{{ config.title | translate }}</strong>
+  </h1>
+  <h2
+    *ngIf="config.heading !== 'h1'"
+    [ngClass]="'h3'"
+    id="{{ config.title | translate | SlugifyPipe }}"
+  >
+    <strong>{{ config.title | translate }}</strong>
+  </h2>
+  <ircc-cl-lib-button
+    [className]="config.anchorType"
+    category="plain"
+    size="small"
+    routerLink="{{ windowPathname }}"
+    fragment="{{ config.title | translate | SlugifyPipe }}"
+    cdkCopyToClipboard="{{ windowOrigin }}{{ windowPathname }}#{{
+      config.title | translate | SlugifyPipe
+    }}"
+  >
+    {{ 'Buttons.CopyURL' | translate }}
+  </ircc-cl-lib-button>
+</div>

--- a/component-library/src/app/components/title-slug-url/title-slug-url.component.scss
+++ b/component-library/src/app/components/title-slug-url/title-slug-url.component.scss
@@ -1,34 +1,17 @@
-:host {
+.title-slug-wrapper {
   display: flex;
-  align-items: baseline;
-  > h1 {
-    margin: {
-      top: 48px;
-      bottom: 24px;
-    };
+  align-items: center;
+}
+
+.h1-heading-type {
+  margin: {
+    top: 48px;
+    bottom: 24px;
   }
-  > h2 {
-    margin: {
-      top: 64px;
-      bottom: 24px;
-    };
-  } 
-
-  > a {
-    margin-left: 12px;
-    position: relative;
-    bottom: 5px;
-    text-decoration: none;
-    color: var(--link-text);
-    font-family: "Lato";
-    padding: 0;
-
-    &.primary {
-      font-size: 16px;
-      font-weight: 400;
-      line-height: 24px;
-      letter-spacing: 0em;
-      text-align: center;
-    }
+}
+.h2-heading-type {
+  margin: {
+    top: 80px;
+    bottom: 24px;
   }
 }

--- a/component-library/src/app/components/title-slug-url/title-slug-url.component.ts
+++ b/component-library/src/app/components/title-slug-url/title-slug-url.component.ts
@@ -42,6 +42,8 @@ export class TitleSlugUrlComponent implements AfterContentInit, OnInit {
     this.translator.onLangChange.subscribe((event: LangChangeEvent) => {
       this.currentLang = event.lang;
     });
+    
+    if (this.config.heading !== 'h1') this.config.heading='h2'
   }
 
   ngAfterContentInit(): void {


### PR DESCRIPTION
**Why are these changes introduced?**
* Related story #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/874903)

**What is this pull request doing?**
* Updated copy url to use plain button instead of using <a> tags
* updated styles for title slug url


**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)
* File names and hierarchies are in keeping with our norms
* Interfaces are named correctly
ngOnInit and constructor is removed when not used 
':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?



**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.