### PR TITLE
Bug-Fix: fixed mobile styles for interactive demo

### DIFF
--- a/component-library/src/app/components/accordion-panel/accordion-container.component.html
+++ b/component-library/src/app/components/accordion-panel/accordion-container.component.html
@@ -1,9 +1,9 @@
 <div class="accordion-panel">
-  <div class="accordion-nav">
+  <div class="accordion-nav {{ config.mobileBehaviour }}">
     <!-- this projection area will appear to the left of the accordion open button-->
-    <div class="accordion-extra-left">
-      <ng-content select="[extraLeft]"></ng-content>
-    </div>
+    <!-- Prettier ignore is added to avoid white spaces being added -->
+    <!-- prettier-ignore -->
+    <div class="accordion-extra-left"><ng-content select="[extraLeft]"></ng-content></div>
     <div class="accordion-expand-button">
       <ircc-cl-lib-button
         *ngIf="config.open === true"
@@ -24,9 +24,9 @@
     </div>
 
     <!-- this projection area will appear to the right of the accordion open button-->
-    <div class="accordion-extra-right">
-      <ng-content select="[extraRight]"></ng-content>
-    </div>
+    <!-- Prettier ignore is added to avoid white spaces being added -->
+    <!-- prettier-ignore -->
+    <div class="accordion-extra-right"><ng-content select="[extraRight]"></ng-content></div>
   </div>
   <div
     [class]="config.open ? 'open accordion-content' : 'close accordion-content'"

--- a/component-library/src/app/components/accordion-panel/accordion-container.component.scss
+++ b/component-library/src/app/components/accordion-panel/accordion-container.component.scss
@@ -20,8 +20,16 @@
     display: grid;
     grid-template-columns: 30% auto 30%;
 
+    &.fullWidth {
+      grid-template-columns: auto auto auto;
+    }
+
     @include device.in-phone-layout() {
       grid-template-columns: auto 30% 30%;
+
+      &.fullWidth {
+        grid-template-columns: 100% auto auto;
+      }
     }
 
     .accordion-extra-left {
@@ -32,6 +40,10 @@
 
       @include device.in-phone-layout() {
         grid-column: 2;
+      }
+
+      &:empty {
+        display: none;
       }
     }
 
@@ -52,6 +64,9 @@
       align-items: center;
       @include device.in-phone-layout() {
         grid-column: 3;
+      }
+      &:empty {
+        display: none;
       }
     }
   }

--- a/component-library/src/app/components/accordion-panel/accordion-container.component.ts
+++ b/component-library/src/app/components/accordion-panel/accordion-container.component.ts
@@ -2,11 +2,16 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { IButtonConfig } from 'ircc-ds-angular-component-library';
 
+export enum mobileBehaviourType {
+  fullWidth = 'fullWidth',
+  column = 'column'
+}
 export interface IAccordionContainerConfig {
   id: string;
   buttonText?: string;
   buttonTextClosed?: string;
   open?: boolean;
+  mobileBehaviour?: keyof typeof mobileBehaviourType;
 }
 
 @Component({
@@ -16,12 +21,14 @@ export interface IAccordionContainerConfig {
 })
 export class accordionContainerComponent implements OnInit {
   @Input() config: IAccordionContainerConfig = {
-    id: ''
+    id: '',
+    mobileBehaviour: mobileBehaviourType.column
   };
   @Input() id: string = '';
   @Input() buttonText: string = '';
   @Input() buttonTextClosed: string = '';
   @Input() open?: boolean | undefined;
+  @Input() mobileBehaviour: keyof typeof mobileBehaviourType | undefined;
 
   @Output() getOpen = new EventEmitter<boolean>();
 
@@ -51,6 +58,7 @@ export class accordionContainerComponent implements OnInit {
     if (this.buttonTextClosed !== '')
       this.config.buttonTextClosed = this.buttonTextClosed;
     if (this.open !== undefined) this.config.open = this.open;
+    if (this.mobileBehaviour !== undefined) this.config.mobileBehaviour = this.mobileBehaviour
   }
 
   openAccordion() {

--- a/component-library/src/app/components/code-viewer/code-viewer.component.ts
+++ b/component-library/src/app/components/code-viewer/code-viewer.component.ts
@@ -13,7 +13,7 @@ import {
   ITabConfig
 } from 'ircc-ds-angular-component-library';
 
-import { IAccordionContainerConfig } from '../accordion-panel/accordion-container.component';
+import { IAccordionContainerConfig, mobileBehaviourType } from '../accordion-panel/accordion-container.component';
 
 export interface ICodeViewerConfig {
   id: string;
@@ -43,7 +43,8 @@ export class codeViewerComponent implements OnInit, OnChanges {
 
   accordionConfig: IAccordionContainerConfig = {
     id: 'codeViewerTabsCccordion',
-    open: this.config.openAccordion
+    open: this.config.openAccordion,
+    mobileBehaviour: mobileBehaviourType.column
   };
 
   openAccordion: boolean = false;

--- a/component-library/src/app/components/interactive-demo/interactive-demo.component.scss
+++ b/component-library/src/app/components/interactive-demo/interactive-demo.component.scss
@@ -1,6 +1,7 @@
-@use "../../../../../core-library/tokens/sizes" as token-size;
-@use "../../../../../core-library/util/size" as size;
-@use "../../../../../core-library/tokens/sizes";
+@use '../../../../../core-library/tokens/sizes' as token-size;
+@use '../../../../../core-library/util/size' as size;
+@use '../../../../../core-library/tokens/sizes';
+@use '../../../../../core-library/util/device' as device;
 
 .container {
   border-radius: 5px;
@@ -47,6 +48,10 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     row-gap: 24px;
+
+    @include device.in-phone-layout() {
+      grid-template-columns: 1fr;
+    }
   }
 
   .tabs {

--- a/component-library/src/app/components/interactive-demo/interactive-demo.component.ts
+++ b/component-library/src/app/components/interactive-demo/interactive-demo.component.ts
@@ -1,8 +1,8 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
 import { IIconButtonIconConfig } from 'ircc-ds-angular-component-library';
-import { IAccordionContainerConfig } from '../accordion-panel/accordion-container.component';
+import { IAccordionContainerConfig, mobileBehaviourType } from '../accordion-panel/accordion-container.component';
 
-export enum ComponentType {
+export enum InteractiveComponentType {
   banner = 'banner'
 }
 
@@ -22,16 +22,29 @@ export class InteractiveDemoComponent implements OnInit {
    component specifically for Banner in the scss file, since 
    banner has a white background and rest have a grey background.
   */
-  @Input() componentType?: keyof typeof ComponentType;
-
+  @Input() componentType?: keyof typeof InteractiveComponentType;
+  mobile = false;
   accordionConfig: IAccordionContainerConfig = {
     id: 'InteractiveDemoComponentAcccordion',
     open: true,
     buttonText: 'DEMO_COMPONENT.ACCORDION_OPEN',
-    buttonTextClosed: 'DEMO_COMPONENT.ACCORDION_CLOSED'
+    buttonTextClosed: 'DEMO_COMPONENT.ACCORDION_CLOSED',
+    mobileBehaviour: mobileBehaviourType.fullWidth
   };
 
+  /** Listens for screen resizes and sets mobile-tablet boolean */
+  @HostListener('window:resize', ['$event'])
+  onResize() {
+    this.mobile = window.innerWidth <= 360;
+    if(this.mobile){
+      this.accordionConfig.open = false;
+    } else {
+      this.accordionConfig.open = true;
+    }
+  }
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.onResize()
+  }
 }

--- a/component-library/src/app/pages/button-documentation/button-doc-code.component.scss
+++ b/component-library/src/app/pages/button-documentation/button-doc-code.component.scss
@@ -1,3 +1,5 @@
+@use '../../../../../core-library/util/device' as device;
+
 .button-container-fluid {
   padding: auto;
   padding-top: 54px;
@@ -17,4 +19,11 @@
   grid-column-end: 2;
   grid-row-start: 1;
   grid-row-end: 1;
+
+  @include device.in-phone-layout() {
+    grid-column-start: 1;
+    grid-column-end: 1;
+    grid-row-start: 2;
+    grid-row-end: 2;
+  }
 }


### PR DESCRIPTION
**Why are these changes introduced?**
* Related story #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/876832))

**What is this pull request doing?**
* Added the following mobile styles for interactive demo
  
  * Accordion should hide when switch to mobile view.
  * Toggle config should switch to single column view
  *  Accordion toggle Heading should center and always take 100% in mobile if only item
  * Fixed other minor styles  


**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)
* File names and hierarchies are in keeping with our norms
* Interfaces are named correctly
ngOnInit and constructor is removed when not used 
':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?



**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.