### PR TITLE
input-documentation page cleanup

### DIFF
--- a/component-library/src/app/components/title-slug-url/title-slug-url.component.ts
+++ b/component-library/src/app/components/title-slug-url/title-slug-url.component.ts
@@ -42,8 +42,8 @@ export class TitleSlugUrlComponent implements AfterContentInit, OnInit {
     this.translator.onLangChange.subscribe((event: LangChangeEvent) => {
       this.currentLang = event.lang;
     });
-    
-    if (this.config.heading !== 'h1') this.config.heading='h2'
+
+    if (this.config.heading !== 'h1') this.config.heading = 'h2';
   }
 
   ngAfterContentInit(): void {

--- a/component-library/src/app/pages/banner-documentation/banner-doc-code.component.ts
+++ b/component-library/src/app/pages/banner-documentation/banner-doc-code.component.ts
@@ -17,8 +17,7 @@ import {
   stringify
 } from '@app/components/code-viewer/code-viewer.component';
 
-const NUMBER_OF_CTA_ALLOWED : number = 3;
-
+const NUMBER_OF_CTA_ALLOWED: number = 3;
 
 @Component({
   selector: 'app-banner-doc-code',
@@ -28,7 +27,7 @@ const NUMBER_OF_CTA_ALLOWED : number = 3;
 export class BannerDocCodeComponent implements OnInit {
   @ViewChild('banner', { static: false }) banner!: ElementRef;
   altLangLink = 'bannerDocumentation';
-  
+
   constructor(
     private translate: TranslateService,
     private lang: LangSwitchService

--- a/component-library/src/app/pages/input-documentation/input-documentation.component.html
+++ b/component-library/src/app/pages/input-documentation/input-documentation.component.html
@@ -1,14 +1,10 @@
 <div class="content-doc-wrapper">
-  <app-title-slug-url
-    [config]="inputTitleSlugConfig"
-    class="h1 emphasis"
-  ></app-title-slug-url>
+  <app-title-slug-url [config]="inputTitleSlugConfig"></app-title-slug-url>
   <p class="body1 intro">{{ 'Input.Intro' | translate }}</p>
 
   <section class="interactive-demo">
     <app-title-slug-url
-      [config]="interactiveDemoSlugConfig"
-      class="h3 emphasis"
+      [config]="headingConfig.interactiveDemoSlugConfig"
     ></app-title-slug-url>
     <p class="body3 demo">{{ 'Input.InteractiveDemoDesc' | translate }}</p>
     <app-input-doc-code></app-input-doc-code>
@@ -16,17 +12,15 @@
 
   <section class="types">
     <app-title-slug-url
-      [config]="typesSlugConfig"
-      class="h3 emphasis"
+      [config]="headingConfig.typesSlugConfig"
     ></app-title-slug-url>
     <h5 class="emphasis type-heading">
       {{ 'Input.PrimaryHeading' | translate }}
     </h5>
     <app-component-preview
       class="h6"
-      copyStyle="<button category='secondary'>{{
-        'Buttons.SecondaryIBtnText' | translate
-      }}</button>"
+      copyText="<ircc-cl-lib-input type='text'></ircc-cl-lib-input>"
+      componentType="input"
     >
       <ircc-cl-lib-input [config]="basicInputConfig"></ircc-cl-lib-input>
     </app-component-preview>
@@ -36,9 +30,8 @@
     </h5>
     <app-component-preview
       class="h6"
-      copyStyle="<button category='secondary'>{{
-        'Buttons.SecondaryIBtnText' | translate
-      }}</button>"
+      copyText="<ircc-cl-lib-input type='text'></ircc-cl-lib-input>"
+      componentType="input"
     >
       <ircc-cl-lib-input [config]="passwordInputConfig"></ircc-cl-lib-input>
     </app-component-preview>
@@ -47,8 +40,7 @@
 
   <section class="configs">
     <app-title-slug-url
-      [config]="configurationSlugConfig"
-      class="h3 emphasis"
+      [config]="headingConfig.configurationSlugConfig"
     ></app-title-slug-url>
     <div class="config-row">
       <div class="column">
@@ -110,8 +102,7 @@
 
   <section class="design-guide">
     <app-title-slug-url
-      [config]="guidelineSlugConfig"
-      class="h3 emphasis"
+      [config]="headingConfig.guidelineSlugConfig"
     ></app-title-slug-url>
     <h5 class="h5 emphasis subtitles">
       {{ 'Input.FieldWidth' | translate }}
@@ -183,26 +174,61 @@
 
   <section class="anatomy">
     <app-title-slug-url
-      [config]="anatomySlugConfig"
-      class="h3 emphasis"
+      [config]="headingConfig.anatomySlugConfig"
     ></app-title-slug-url>
     <img
       src="assets/img/input-content/input-anatomy.png"
       alt="{{ 'Input.AnatomyImgAlt' | translate }}"
     /><br />
-    <ng-container *ngFor="let content of anatomyContentItems; let i = index">
-      <span class="round-purple-num">{{ i + 1 }}</span>
-      <h5 class="h5 emphasis round-purple-num">
-        {{ content.title | translate }}
-      </h5>
-      <p class="body3 subtext-8">{{ content.description | translate }}</p>
-    </ng-container>
+    <span class="round-purple-num">1</span>
+    <h5 class="h5 emphasis round-purple-num">
+      {{ 'Input.AnatomyLabelHeading' | translate }}
+    </h5>
+    <p class="body3 anatomy">{{ 'Input.AnatomyLabelText' | translate }}</p>
+    <span class="round-purple-num">2</span>
+    <h5 class="h5 emphasis round-purple-num">
+      {{ 'Input.AnatomyRequiredIndicatorHeading' | translate }}
+    </h5>
+    <p class="body3 anatomy">
+      {{ 'Input.AnatomyRequiredIndicatorText' | translate }}
+    </p>
+    <span class="round-purple-num">3</span>
+    <h5 class="h5 emphasis round-purple-num">
+      {{ 'Input.AnatomyDescHeading' | translate }}
+    </h5>
+    <p class="body3 anatomy">{{ 'Input.AnatomyDescText' | translate }}</p>
+    <span class="round-purple-num">4</span>
+    <h5 class="h5 emphasis round-purple-num">
+      {{ 'Input.AnatomyHintHeading' | translate }}
+    </h5>
+    <p class="body3 anatomy">{{ 'Input.AnatomyHintText' | translate }}</p>
+    <span class="round-purple-num">5</span>
+    <h5 class="h5 emphasis round-purple-num">
+      {{ 'Input.AnatomyInputFieldHeading' | translate }}
+    </h5>
+    <p class="body3 anatomy">{{ 'Input.AnatomyInputFieldText' | translate }}</p>
+    <span class="round-purple-num">6</span>
+    <h5 class="h5 emphasis round-purple-num">
+      {{ 'Input.AnatomyInputContentHeading' | translate }}
+    </h5>
+    <p class="body3 anatomy">
+      {{ 'Input.AnatomyInputContentText' | translate }}
+    </p>
+    <span class="round-purple-num">7</span>
+    <h5 class="h5 emphasis round-purple-num">
+      {{ 'Input.AnatomyErrorHeading' | translate }}
+    </h5>
+    <p class="body3 anatomy">{{ 'Input.AnatomyErrorText' | translate }}</p>
+    <span class="round-purple-num">8</span>
+    <h5 class="h5 emphasis round-purple-num">
+      {{ 'Input.AnatomyPasswordHeading' | translate }}
+    </h5>
+    <p class="body3 anatomy">{{ 'Input.AnatomyPasswordText' | translate }}</p>
   </section>
 
   <section class="specs">
     <app-title-slug-url
-      [config]="specsSlugConfig"
-      class="h3 emphasis"
+      [config]="headingConfig.specsSlugConfig"
     ></app-title-slug-url>
     <img
       class="single-img"
@@ -213,8 +239,7 @@
 
   <section class="content-guidelines">
     <app-title-slug-url
-      [config]="contentGuideSlugConfig"
-      lass="h3 emphasis"
+      [config]="headingConfig.contentGuideSlugConfig"
     ></app-title-slug-url>
 
     <h5 class="subtitles">{{ 'Input.WriteLabelsHeading' | translate }}</h5>
@@ -450,23 +475,33 @@
 
   <section class="usage-figma">
     <app-title-slug-url
-      [config]="figmaSlugConfig"
-      class="h3 emphasis"
+      [config]="headingConfig.figmaSlugConfig"
     ></app-title-slug-url>
     <div class="row">
       <div class="figma-usage">
-        <h5 class="h5 emphasis subtitles">
-          {{ 'Input.FigmaDirectionsHeading' | translate }}
+        <h5 class="sub-headings">
+          {{ 'General.FigmaDirectionsHeading' | translate }}
         </h5>
         <ol>
           <li
             class="body3 emphasis"
-            *ngFor="let direction of figmaDirections"
-            [innerHtml]="direction | translate"
+            [innerHTML]="'Input.FigmaDirectionsListItem1' | translate"
+          ></li>
+          <li
+            class="body3 emphasis"
+            [innerHTML]="'Input.FigmaDirectionsListItem2' | translate"
+          ></li>
+          <li
+            class="body3 emphasis"
+            [innerHTML]="'Input.FigmaDirectionsListItem3' | translate"
+          ></li>
+          <li
+            class="body3 emphasis"
+            [innerHTML]="'Input.FigmaDirectionsListItem4' | translate"
           ></li>
         </ol>
       </div>
-      <div class="image-container-1">
+      <div class="image-1 image-container-1">
         <img
           src="assets/img/input-content/figma-usage-1.png"
           alt="{{ 'Input.FigmaDirectionsImgAlt' | translate }}"
@@ -475,7 +510,7 @@
     </div>
     <div class="three-column-row">
       <div class="figma-usage">
-        <h5 class="h5 emphasis subtitles">
+        <h5 class="sub-headings">
           {{ 'Input.AccessInputsHeading' | translate }}
         </h5>
         <ol>
@@ -489,24 +524,25 @@
           ></li>
         </ol>
       </div>
-      <div class="image-container-2">
-        <img
-          src="assets/img/input-content/figma-usage-2.png"
-          alt="{{ 'Input.AccessInputsImgAlt1' | translate }}"
-        />
-      </div>
-      <div>
-        <img
-          src="assets/img/input-content/figma-usage-3.png"
-          alt="{{ 'Input.AccessInputsImgAlt2' | translate }}"
-        />
+      <div class="image-container-wrapper">
+        <div class="image-2 image-container">
+          <img
+            src="assets/img/input-content/figma-usage-2.png"
+            alt="{{ 'Input.AccessInputsImgAlt1' | translate }}"
+          />
+        </div>
+        <div class="image-3 image-container">
+          <img
+            src="assets/img/input-content/figma-usage-3.png"
+            alt="{{ 'Input.AccessInputsImgAlt2' | translate }}"
+          />
+        </div>
       </div>
     </div>
   </section>
   <section class="accessibility">
     <app-title-slug-url
-      [config]="accessibilitySlugConfig"
-      class="h3 emphasis"
+      [config]="headingConfig.accessibilitySlugConfig"
     ></app-title-slug-url>
     <h5 class="h5 emphasis subtitles">
       {{ 'Input.AccessibilityColourHeading' | translate }}
@@ -525,8 +561,31 @@
     </h5>
     <ul>
       <li
-        *ngFor="let content of accessibilityContentItems"
-        [innerHtml]="content | translate"
+        [innerHtml]="'Input.AccessibilityContentItem1' | translate"
+        class="body3"
+      ></li>
+      <li
+        [innerHtml]="'Input.AccessibilityContentItem2' | translate"
+        class="body3"
+      ></li>
+      <li
+        [innerHtml]="'Input.AccessibilityContentItem3' | translate"
+        class="body3"
+      ></li>
+      <li
+        [innerHtml]="'Input.AccessibilityContentItem4' | translate"
+        class="body3"
+      ></li>
+      <li
+        [innerHtml]="'Input.AccessibilityContentItem5' | translate"
+        class="body3"
+      ></li>
+      <li
+        [innerHtml]="'Input.AccessibilityContentItem6' | translate"
+        class="body3"
+      ></li>
+      <li
+        [innerHtml]="'Input.AccessibilityContentItem7' | translate"
         class="body3"
       ></li>
     </ul>
@@ -542,8 +601,7 @@
   </section>
   <section class="research">
     <app-title-slug-url
-      [config]="researchSlugConfig"
-      class="h3 emphasis"
+      [config]="headingConfig.researchSlugConfig"
     ></app-title-slug-url>
     <p class="body3 subtext-1">{{ 'Input.ResearchText' | translate }}</p>
   </section>

--- a/component-library/src/app/pages/input-documentation/input-documentation.component.scss
+++ b/component-library/src/app/pages/input-documentation/input-documentation.component.scss
@@ -38,78 +38,80 @@ h3 {
   margin-bottom: 12px;
 }
 
-.body3.subtext-1 {
-  margin-top: 12px;
-  margin-bottom: 24px;
-}
+.body3 {
+  .subtext-1 {
+    margin-top: 12px;
+    margin-bottom: 24px;
+  }
 
-.body3.subtext-2 {
-  margin-top: 12px;
-  margin-bottom: 32px;
-}
+  .subtext-2 {
+    margin-top: 12px;
+    margin-bottom: 32px;
+  }
 
-.body3.subtext-3 {
-  margin-top: 12px;
-  margin-bottom: 12px;
-}
+  .subtext-3 {
+    margin-top: 12px;
+    margin-bottom: 12px;
+  }
 
-.body3.subtext-4 {
-  margin-top: 8px;
-  margin-bottom: 32px;
-}
+  .subtext-4 {
+    margin-top: 8px;
+    margin-bottom: 32px;
+  }
 
-.body3.subtext-5 {
-  margin-top: 8px;
-  margin-bottom: 24px;
-}
+  .subtext-5 {
+    margin-top: 8px;
+    margin-bottom: 24px;
+  }
 
-.body3.subtext-6 {
-  margin-top: 8px;
-  margin-bottom: 48px;
-}
+  .subtext-6 {
+    margin-top: 8px;
+    margin-bottom: 48px;
+  }
 
-.body3.subtext-7 {
-  margin-top: 8px;
-  margin-bottom: 44px;
-}
+  .subtext-7 {
+    margin-top: 8px;
+    margin-bottom: 44px;
+  }
 
-.body3.subtext-8 {
-  margin-top: 8px;
-  margin-bottom: 0px;
-}
+  .subtext-8 {
+    margin-top: 8px;
+    margin-bottom: 0px;
+  }
 
-.body3.subtext-9 {
-  margin-top: 8px;
-  margin-bottom: 12px;
-}
+  .subtext-9 {
+    margin-top: 8px;
+    margin-bottom: 12px;
+  }
 
-.body3.subtext-10 {
-  margin-top: 8px;
-  margin-bottom: 68px;
-}
+  .subtext-10 {
+    margin-top: 8px;
+    margin-bottom: 68px;
+  }
 
-.body3.subtext-11 {
-  margin-top: 8px;
-  margin-bottom: 88px;
-}
+  .subtext-11 {
+    margin-top: 8px;
+    margin-bottom: 88px;
+  }
 
-.body3.subtext-12 {
-  margin-top: 8px;
-  margin-bottom: 52px;
-}
+  .subtext-12 {
+    margin-top: 8px;
+    margin-bottom: 52px;
+  }
 
-.body3.subtext-13 {
-  margin-top: 8px;
-  margin-bottom: 0px;
-}
+  .subtext-13 {
+    margin-top: 8px;
+    margin-bottom: 0px;
+  }
 
-.body3.last {
-  margin-top: 12px;
-  margin-bottom: 0px;
-}
+  .last {
+    margin-top: 12px;
+    margin-bottom: 0px;
+  }
 
-.body3.anatomy {
-  margin-bottom: 0px;
+  .anatomy {
+    margin-bottom: 0px;
+  }
 }
 
 .config-heading {
@@ -213,31 +215,44 @@ span {
   justify-content: flex-start;
 }
 
-.figma-usage {
-  max-width: 547px;
-  margin-right: 20px;
+.usage-figma {
+  .three-column-row {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: column;
 
-  @include device.in-tablet-layout() {
-    max-width: 444px;
+    @include device.in-tablet-layout() {
+      flex-wrap: wrap;
+    }
+
+    .image-container-wrapper {
+      display: flex;
+      flex-direction: row;
+
+      @include device.in-tablet-layout() {
+        display: flex;
+        flex-direction: column;
+      }
+
+      @include device.in-phone-layout() {
+        display: flex;
+        flex-direction: column;
+      }
+    }
   }
-}
 
-.image-container-1 {
-  max-width: 232px;
-  height: auto;
-  filter: drop-shadow(0px 20px 40px rgba(0, 0, 0, 0.2));
-}
+  .image-1 {
+    max-width: 232px;
+    height: auto;
+  }
 
-.image-container-2 {
-  filter: drop-shadow(0px 20px 40px rgba(0, 0, 0, 0.2));
-}
+  .image-2 {
+    max-width: 505px;
+    height: auto;
+  }
 
-.three-column-row {
-  display: flex;
-  justify-content: space-between;
-
-
-  @include device.in-tablet-layout() {
-    flex-wrap: wrap;
+  .image-3 {
+    max-width: 239px;
+    height: auto;
   }
 }

--- a/component-library/src/app/pages/input-documentation/input-documentation.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-documentation.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@app/components/title-slug-url/title-slug-url.component';
 import { LangSwitchService } from '@app/share/lan-switch/lang-switch.service';
 import { SlugifyPipe } from '@app/share/pipe-slugify.pipe';
-import { ContentItem } from '@app/share/lan-switch/interface/content-item.interface';
+import { docPageheadingConfig } from '@app/share/documentation-page-headings';
 
 @Component({
   selector: 'app-input-documentation',
@@ -20,6 +20,7 @@ import { ContentItem } from '@app/share/lan-switch/interface/content-item.interf
 export class InputDocumentationComponent implements OnInit {
   currentLanguage: string = '';
   anchorType = slugAnchorType;
+  headingConfig = docPageheadingConfig;
 
   altLangLink = 'inputDocumentation';
 
@@ -47,108 +48,6 @@ export class InputDocumentationComponent implements OnInit {
     heading: 'h1',
     anchorType: slugAnchorType.primary
   };
-
-  interactiveDemoSlugConfig: slugTitleURLConfig = {
-    title: 'Input.InteractiveDemo',
-    anchorType: slugAnchorType.primary
-  };
-
-  typesSlugConfig: slugTitleURLConfig = {
-    title: 'Input.TypesHeading',
-    anchorType: slugAnchorType.primary
-  };
-
-  configurationSlugConfig: slugTitleURLConfig = {
-    title: 'Input.ConfigurationsHeading',
-    anchorType: slugAnchorType.primary
-  };
-
-  guidelineSlugConfig: slugTitleURLConfig = {
-    title: 'Input.DesignGuidelinesHeading',
-    anchorType: slugAnchorType.primary
-  };
-
-  anatomySlugConfig: slugTitleURLConfig = {
-    title: 'Input.AnatomyHeading',
-    anchorType: slugAnchorType.primary
-  };
-
-  specsSlugConfig: slugTitleURLConfig = {
-    title: 'Input.SpecsHeading',
-    anchorType: slugAnchorType.primary
-  };
-
-  contentGuideSlugConfig: slugTitleURLConfig = {
-    title: 'Input.ContentGuidelinesHeading',
-    anchorType: slugAnchorType.primary
-  };
-
-  figmaSlugConfig: slugTitleURLConfig = {
-    title: 'Input.FigmaHeading',
-    anchorType: slugAnchorType.primary
-  };
-
-  accessibilitySlugConfig: slugTitleURLConfig = {
-    title: 'Input.AccessibilityHeading',
-    anchorType: slugAnchorType.primary
-  };
-
-  researchSlugConfig: slugTitleURLConfig = {
-    title: 'Input.ResearchHeading',
-    anchorType: slugAnchorType.primary
-  };
-
-  figmaDirections: string[] = [
-    'Input.FigmaDirectionsListItem1',
-    'Input.FigmaDirectionsListItem2',
-    'Input.FigmaDirectionsListItem3',
-    'Input.FigmaDirectionsListItem4'
-  ];
-
-  accessibilityContentItems: string[] = [
-    'Input.AccessibilityContentItem1',
-    'Input.AccessibilityContentItem2',
-    'Input.AccessibilityContentItem3',
-    'Input.AccessibilityContentItem4',
-    'Input.AccessibilityContentItem5',
-    'Input.AccessibilityContentItem6',
-    'Input.AccessibilityContentItem7'
-  ];
-
-  anatomyContentItems: ContentItem[] = [
-    {
-      title: 'Input.AnatomyLabelHeading',
-      description: 'Input.AnatomyLabelText'
-    },
-    {
-      title: 'Input.AnatomyRequiredIndicatorHeading',
-      description: 'Input.AnatomyRequiredIndicatorText'
-    },
-    {
-      title: 'Input.AnatomyDescHeading',
-      description: 'Input.AnatomyDescText'
-    },
-    {
-      title: 'Input.AnatomyHintHeading',
-      description: 'Input.AnatomyHintText'
-    },
-    {
-      title: 'Input.AnatomyInputFieldHeading',
-      description: 'Input.AnatomyInputFieldText'
-    },
-    {
-      title: 'Input.AnatomyInputContentHeading',
-      description: 'Input.AnatomyInputContentText'
-    },
-    {
-      title: 'Input.AnatomyErrorHeading',
-      description: 'Input.AnatomyErrorText'
-    },
-    {
-      title: 'Input.AnatomyPasswordHeading',
-      description: 'Input.AnatomyPasswordText'
-    }
-  ];
 
   constructor(
     private translate: TranslateService,

--- a/component-library/src/app/share/documentation-page-headings.ts
+++ b/component-library/src/app/share/documentation-page-headings.ts
@@ -1,0 +1,53 @@
+import { slugAnchorType } from '@app/components/title-slug-url/title-slug-url.component';
+
+export const docPageheadingConfig: any = {
+  interactiveDemoSlugConfig: {
+    title: 'General.InteractiveDemo',
+    anchorType: slugAnchorType.primary
+  },
+
+  typesSlugConfig: {
+    title: 'General.TypesHeading',
+    anchorType: slugAnchorType.primary
+  },
+
+  configurationSlugConfig: {
+    title: 'General.ConfigurationsHeading',
+    anchorType: slugAnchorType.primary
+  },
+
+  guidelineSlugConfig: {
+    title: 'General.DesignGuidelinesHeading',
+    anchorType: slugAnchorType.primary
+  },
+
+  anatomySlugConfig: {
+    title: 'General.AnatomyHeading',
+    anchorType: slugAnchorType.primary
+  },
+
+  specsSlugConfig: {
+    title: 'General.SpecsHeading',
+    anchorType: slugAnchorType.primary
+  },
+
+  contentGuideSlugConfig: {
+    title: 'General.ContentGuidelinesHeading',
+    anchorType: slugAnchorType.primary
+  },
+
+  figmaSlugConfig: {
+    title: 'General.FigmaHeading',
+    anchorType: slugAnchorType.primary
+  },
+
+  accessibilitySlugConfig: {
+    title: 'General.AccessibilityHeading',
+    anchorType: slugAnchorType.primary
+  },
+
+  researchSlugConfig: {
+    title: 'General.ResearchHeading',
+    anchorType: slugAnchorType.primary
+  }
+};

--- a/component-library/src/app/share/lan-switch/interface/content-item.interface.ts
+++ b/component-library/src/app/share/lan-switch/interface/content-item.interface.ts
@@ -1,5 +1,0 @@
-export interface ContentItem {
-  title: string;
-  description: string;
-  number?: number;
-}

--- a/component-library/src/app/shell/shell.component.html
+++ b/component-library/src/app/shell/shell.component.html
@@ -14,6 +14,7 @@
         <a routerLink="/en/michael-en">michael</a>
         <a routerLink="/en/mike-en">mike</a>
         <a routerLink="/en/naseer-en">naseer</a>
+        <a routerLink="/en/bobby-en">bobby</a>
         <a routerLink="/en/accessibility-demo">Accessibility Demo</a>
         <a routerLink="/en/banner-doc">Banner Documentation</a>
         <a routerLink="/en/codeview">Codeview</a>


### PR DESCRIPTION
**PR Approval Template**

**Why are these changes introduced?**
* Following team discussion on code optimization versus static template - refactored input documentation to remove all instances of ngFor and some small issues flagged


**What is this pull request doing?**
* Moved title slug configs to general file and clean up the component ts file
* Small fix to the figma section and how images were behaving responsively
* Clean up stylesheet


**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)
* File names and hierarchies are in keeping with our norms
* Interfaces are named correctly
ngOnInit and constructor is removed when not used 
':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?



**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.