### PR TITLE
Bug/banner code block

### DIFF
--- a/component-library/component-lib/src/lib/banner-component/banner/banner.component.ts
+++ b/component-library/component-lib/src/lib/banner-component/banner/banner.component.ts
@@ -52,9 +52,11 @@ export class BannerComponent implements OnInit {
   lineVisible = true;
   textId = '';
 
-  @Input() config?: IBannerConfig;
+  @Input() config: IBannerConfig = {
+    id: ''
+  };
   @Input() id?: string;
-  @Input() ariaDissmissible?: string = 'close';
+  @Input() ariaDissmissible?: string;
 
   @Output() btnEvent = new EventEmitter();
 
@@ -106,8 +108,14 @@ export class BannerComponent implements OnInit {
       });
     }
 
-    if (this.config && !this.config.ariaDissmissible) {
+    if (this.ariaDissmissible) {
       this.config.ariaDissmissible = this.ariaDissmissible;
+    }
+
+    if (!this.config.ariaDissmissible || this.config.ariaDissmissible === '') {
+      if (this.config.dismissible) {
+        this.config.ariaDissmissible = 'close';
+      }
     }
   }
 

--- a/component-library/src/app/pages/banner-documentation/banner-doc-code.component.ts
+++ b/component-library/src/app/pages/banner-documentation/banner-doc-code.component.ts
@@ -440,6 +440,19 @@ export class BannerDocCodeComponent implements OnInit {
   }
 
   /**
+   * Sets dismissable to true or false and sets ariaDismissable respectively based on radio selection
+   */
+  handleCloseToggle(value: any) {
+    if (value['showCloseToggle'] === 'True') {
+      this.bannerConfig.dismissible = true;
+      this.bannerConfig.ariaDissmissible = 'close';
+    } else {
+      this.bannerConfig.dismissible = false;
+      this.bannerConfig.ariaDissmissible = '';
+    }
+  }
+
+  /**
    * Return mapping of input config from form values
    */
   private parseToggleConfig(value: any): IBannerConfig {
@@ -454,8 +467,7 @@ export class BannerDocCodeComponent implements OnInit {
         value['showDescToggle'] === 'True'
           ? (this.bannerConfig.content =
               'Description text lorem ipsum dolor sit amet consecteteur adipiscing elit.')
-          : '',
-      dismissible: value['showCloseToggle'] === 'True' ? true : false
+          : ''
     };
   }
 
@@ -496,7 +508,9 @@ export class BannerDocCodeComponent implements OnInit {
     this.form_interactive_banner.valueChanges.subscribe((value: any) => {
       this.handlePrimaryButtonToggle(value);
       this.handlePlainButtonToggle(value);
-      this.handleSecondaryButtonToggle(value), this.handleLinkToggle(value);
+      this.handleSecondaryButtonToggle(value);
+      this.handleLinkToggle(value);
+      this.handleCloseToggle(value);
       this.bannerConfig = this.parseToggleConfig(value);
       this.parseCodeViewConfig();
     });


### PR DESCRIPTION
**Why are these changes introduced?**
* Tony found a issue in the banner-code block, where ariaDissmissable would be added to code block regardless of dismissible 
   was set to true or false. This PR fixes that issue.
   
**What is this pull request doing?**
* Fixed default aria dismissible value, default value is only set when dismissible is set to true.
*  Fixed ariaDismissable value in code block so it only shows up when dismissible is set to true.

**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)

** File names and hierarchies are in keeping with our norms:
* Interfaces start with 'I' followed by a capital letter and camel case (IInterfaceExample) and are descriptive
* Subjects are suffixed with 'Subj' (ex: thisIsAnExampleSubj)
* Subscriptions are suffixed with 'Sub' (ex: thisIsAnExampleSub)
* Observables ere suffixed with 'Obs$' (ex: thisIsAnExampleObs$)
* Class and variable names are camel case
* Class names should start with a capital letter (i.e. ExampleClass)
* Variable names should start with a lower case letter (i.e thisIsAnExampleVariable)
* All caps and underscores are used for exported constants (THIS_IS_A_CONSTANT)
* Names are all spelled correctly
* ngOnInit and constructor is removed when not used
* ':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?

**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.