### PR TITLE
Bug: Breadcrumb overflow menu is not as per the design

### DIFF
--- a/core-library/component-styling/breadcrumb/_breadcrumb.scss
+++ b/core-library/component-styling/breadcrumb/_breadcrumb.scss
@@ -217,11 +217,18 @@
     position: absolute;
 
     ircc-cl-lib-breadcrumb-link {
+      &:hover {
+        background-color: var(--generic-active);
+      }
+
       a {
+        padding: 0;
+
         --link-text: var(--grey-12);
 
         &:hover {
           color: var(--grey-12);
+          background: none;
         }
       }
     }

--- a/core-library/component-styling/breadcrumb/_breadcrumb.scss
+++ b/core-library/component-styling/breadcrumb/_breadcrumb.scss
@@ -215,6 +215,16 @@
     left: -58px;
     padding: 8px 0;
     position: absolute;
+
+    ircc-cl-lib-breadcrumb-link {
+      a {
+        --link-text: var(--grey-12);
+
+        &:hover {
+          color: var(--grey-12);
+        }
+      }
+    }
   }
 
   @include size.selector(small) {


### PR DESCRIPTION
Why are these changes introduced?
- Related story [907943](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_boards/board/t/JL%20-%20Design%20System/Backlog%20items/?workitem=907943)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-breadcrumb_overflow/en/michael-en)

What is this pull request doing?

- Correct color on overflow links
- Correct hover state on overflow links

Reviewer checklist:

- Compare breadcrumb overflow with [Figma design](https://www.figma.com/file/TSKk5lWdgAvZdE836kWcbK/Patterns?type=design&node-id=4129-67016&t=8H0TTHcDAhzSXpjT-4)