### PR TITLE
Qa/bugfix 883882 docsite

### DIFF
--- a/component-library/src/app/pages/overview/overview.component.scss
+++ b/component-library/src/app/pages/overview/overview.component.scss
@@ -3,8 +3,10 @@
 
 :host {
   @include grid.row;
-  > .content-doc-wrapper {
+
+  >.content-doc-wrapper {
     @include grid.col-12;
+
     @include grid.up-laptop-layout {
       @include grid.col-12;
     }
@@ -12,6 +14,7 @@
     .sub-title {
       margin-bottom: 24px;
     }
+
     .overviewTxt {
       @include typography.fontSet(body, 1, regular);
       margin: 0;
@@ -19,26 +22,31 @@
 
     .wrapper-container {
       margin-top: 64px;
-      > .box {
+
+      >.box {
         padding-bottom: 12px;
+
         // This can be replaced by Bootstrap's gutter
         &:nth-child(1) {
           @include grid.up-phone-layout {
             padding-right: 6px;
           }
         }
+
         &:nth-child(2) {
           @include grid.up-phone-layout {
             padding-left: 6px;
           }
         }
       }
-      .for-designers, .for-devs {
+
+      .for-designers,
+      .for-devs {
         // min-height: 174px;
         border: 1px solid;
         border-color: var(--divider);
         border-radius: 12px;
-        padding: 20px 24px 20px 24px;
+        padding: 20px 24px 44px 24px;
 
         h3 {
           margin: 0;

--- a/component-library/src/app/shell/shell.component.html
+++ b/component-library/src/app/shell/shell.component.html
@@ -38,7 +38,7 @@
         <div class="content-area-responsive">
           <div class="page-content">
             <router-outlet></router-outlet>
-            <p>{{ 'Home.DateModified' | translate }}: 2023-02-10</p>
+            <p class="version">{{ 'Home.DateModified' | translate }}: 2023-02-10</p>
           </div>
         </div>
       </div>

--- a/component-library/src/app/shell/shell.component.html
+++ b/component-library/src/app/shell/shell.component.html
@@ -38,7 +38,9 @@
         <div class="content-area-responsive">
           <div class="page-content">
             <router-outlet></router-outlet>
-            <p class="version">{{ 'Home.DateModified' | translate }}: 2023-02-10</p>
+            <p class="version">
+              {{ 'Home.DateModified' | translate }}: 2023-02-10
+            </p>
           </div>
         </div>
       </div>

--- a/component-library/src/app/shell/shell.component.html
+++ b/component-library/src/app/shell/shell.component.html
@@ -37,12 +37,12 @@
       >
         <div class="content-area-responsive">
           <div class="page-content">
-            <router-outlet></router-outlet>            
+            <router-outlet></router-outlet>
             <!-- Footer -->
             <ircc-cl-lib-footer>
               <p class="version">
                 {{ 'Home.DateModified' | translate }}: 2023-02-10
-              </p> 
+              </p>
             </ircc-cl-lib-footer>
           </div>
         </div>

--- a/component-library/src/app/shell/shell.component.html
+++ b/component-library/src/app/shell/shell.component.html
@@ -37,15 +37,16 @@
       >
         <div class="content-area-responsive">
           <div class="page-content">
-            <router-outlet></router-outlet>
-            <p class="version">
-              {{ 'Home.DateModified' | translate }}: 2023-02-10
-            </p>
+            <router-outlet></router-outlet>            
+            <!-- Footer -->
+            <ircc-cl-lib-footer>
+              <p class="version">
+                {{ 'Home.DateModified' | translate }}: 2023-02-10
+              </p> 
+            </ircc-cl-lib-footer>
           </div>
         </div>
       </div>
     </div>
   </main>
-  <!-- Footer -->
-  <ircc-cl-lib-footer> </ircc-cl-lib-footer>
 </div>

--- a/component-library/src/app/shell/shell.component.scss
+++ b/component-library/src/app/shell/shell.component.scss
@@ -1,3 +1,4 @@
+@use '~@ircc-ca/ds-sdc-core/typography/typography';
 @use '../../../../core-library/tokens/sizes';
 @use '../../../../core-library/util/device';
 @use '../../../../core-library/util/color' as color;
@@ -16,9 +17,11 @@ $mobile-padding: 16px;
   z-index: 100;
   position: fixed;
   border-bottom: 1px solid var(--divider);
+
   @include un-tablet-layout {
     left: 0;
   }
+
   .container {
     display: flex;
     justify-content: space-between;
@@ -30,9 +33,14 @@ $mobile-padding: 16px;
       @include un-tablet-layout {
         padding: 0 $tablet-padding;
       }
+
       @include in-phone-layout {
         padding: 0 $mobile-padding;
       }
+    }
+
+    .strong {
+      margin: 24px 0;
     }
   }
 }
@@ -51,55 +59,74 @@ $mobile-padding: 16px;
 
   &.top {
     margin-top: 175px;
+
     @include un-tablet-layout {
       margin-top: 180px;
     }
   }
 
-  > app-side-nav.left-nav {
+  >app-side-nav.left-nav {
     @include up-laptop-layout {
       @include col-2;
     }
+
     @include in-desktop-layout {
       @include col-2;
       margin-right: -1px;
     }
+
     @include un-tablet-layout {
       @include col-12;
     }
   }
+
   .content[role='main'] {
     box-sizing: border-box;
     min-height: calc(100vh - 60px);
 
     @include col-12;
+
     @include in-tablet-layout {
       @include col-12;
     }
+
     @include up-laptop-layout {
       @include col-10;
       padding-left: sizes.$fixed-36;
     }
+
     @include in-desktop-layout {
       padding-left: sizes.$fixed-40;
     }
+
     @include un-tablet-layout {
       @include col-12;
       padding: 0 $tablet-padding;
     }
+
     @include in-phone-layout {
       padding: 0 $mobile-padding;
     }
+
     .page-content {
       width: 100%;
+
+      .version {
+        margin: 14px 0 10px 0;
+        @include typography.fontSet(body, 3, regular);
+      }
+
       .content-doc-wrapper {
         box-sizing: border-box;
+
         @include device.in-desktop-layout {
           padding-right: sizes.$fixed-40;
         }
+
         @include device.in-desktop-layout {
           padding-right: sizes.$fixed-20;
         }
+
         img {
           max-width: 100%;
         }

--- a/component-library/src/app/shell/shell.component.scss
+++ b/component-library/src/app/shell/shell.component.scss
@@ -112,7 +112,7 @@ $mobile-padding: 16px;
       width: 100%;
 
       .version {
-        margin: 14px 0 10px 0;
+        margin: 0;
         @include typography.fontSet(body, 3, regular);
       }
 

--- a/component-library/src/app/shell/shell.component.scss
+++ b/component-library/src/app/shell/shell.component.scss
@@ -40,7 +40,8 @@ $mobile-padding: 16px;
     }
 
     .strong {
-      margin: 24px 0;
+      padding: 24px 0;
+      margin: 0;
     }
   }
 }

--- a/core-library/component-styling/footer/_footer.scss
+++ b/core-library/component-styling/footer/_footer.scss
@@ -63,7 +63,7 @@
 
   .item1 {
     align-self: center;
-
+    padding: 14px 0 10px 0;
     @include device.in-phone-layout () {
       margin-left: sizes.$fixed-8;
     }

--- a/core-library/component-styling/footer/_footer.scss
+++ b/core-library/component-styling/footer/_footer.scss
@@ -2,32 +2,37 @@
 @use '../../tokens/sizes' as sizes;
 @use '../../layout/layout-grid' as layout-grid;
 @use '../../util/device' as device;
- 
+
 @mixin selector {
-    ircc-cl-lib-footer#{template-const.$escape} {
-      @content;
-    }
+  ircc-cl-lib-footer#{template-const.$escape} {
+    @content;
+  }
 }
 
 @mixin create {
-    @include selector() {
-      @include layout();
-    }
+  @include selector() {
+    @include layout();
+  }
 }
 
 @mixin layout {
-//copied from component scss file - can be leveraged
+  //copied from component scss file - can be leveraged
 
   .footing {
-    margin-top: sizes.$fixed-16;
-    margin-bottom: sizes.$fixed-16;
+    margin-top: 94px;
+    margin-bottom: 58px;
   }
 
   .grid-container {
     display: grid;
     @include layout-grid.grid(max-content auto, auto);
-    * {grid-column: auto / span 1};
-    
+
+    * {
+      grid-column: auto / span 1
+    }
+
+    ;
+
     align-items: center;
 
     img {
@@ -35,24 +40,30 @@
         right: 1.07px;
         top: 14px;
         bottom: 14px;
-      };
+      }
+
+      ;
       height: 16px;
 
       @include device.in-phone-layout {
         min-width: 100px;
         height: 22.93px;
+
         margin: {
           top: 24px;
           right: 9.07px;
           left: 16px;
           bottom: 28.48px;
-        };
+        }
+
+        ;
       }
     }
   }
 
   .item1 {
     align-self: center;
+
     @include device.in-phone-layout () {
       margin-left: sizes.$fixed-8;
     }

--- a/core-library/component-styling/footer/_footer.scss
+++ b/core-library/component-styling/footer/_footer.scss
@@ -19,8 +19,8 @@
   //copied from component scss file - can be leveraged
 
   .footing {
-    margin-top: 94px;
-    margin-bottom: 58px;
+    margin-top: 80px;
+    margin-bottom: 48px;
   }
 
   .grid-container {

--- a/core-library/component-styling/header/_header.scss
+++ b/core-library/component-styling/header/_header.scss
@@ -33,14 +33,13 @@
       display: flex;
       justify-content: space-between;
       margin: 0;
-      padding: 0;
+      padding: 24px 0;
     }
 
     .image-container {
       align-self: center;
       width: 296.47px;
       padding: 0;
-      margin: 24px 0;
 
       @include device.in-phone-layout() {
         width: 249px;
@@ -76,9 +75,6 @@
   //container query which applies margins if the container is 16px less than the view width
   // i.e. if the header is spanning almost the entire screen then we will indent the image and lang toggle so they aren't cut off
   @container header-container (width > 90vw) {
-    .image-container {
-      margin-left: 20px;
-    }
 
     .languageSwitch {
       margin-right: 20px;

--- a/core-library/component-styling/header/_header.scss
+++ b/core-library/component-styling/header/_header.scss
@@ -40,6 +40,7 @@
       align-self: center;
       width: 296.47px;
       padding: 0;
+      margin: 24px 0;
 
       @include device.in-phone-layout() {
         width: 249px;
@@ -101,6 +102,7 @@
       margin-right: -8px;
       margin-left: -8px;
     }
+
     //allows headerLine to span entire view width even when the margin is applied to the header container
     @media (max-width: 979px) {
       margin-right: -8px;

--- a/core-library/component-styling/header/_header.scss
+++ b/core-library/component-styling/header/_header.scss
@@ -33,13 +33,12 @@
       display: flex;
       justify-content: space-between;
       margin: 0;
-      padding: 24px 0;
     }
 
     .image-container {
       align-self: center;
       width: 296.47px;
-      padding: 0;
+      padding: 24px 0;
 
       @include device.in-phone-layout() {
         width: 249px;


### PR DESCRIPTION
**PR Approval Template**
**Why are these changes introduced?**
* Related story #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/883882))
* QA LINK #([URL](https://d1whfh0luwluq8.cloudfront.net/qa-bugfix-883882-docsite/index.html))


**What is this pull request doing?**
* Fixes the three doc-site bugs in the backlog:
* Add margin top and bottom to the government of Canada logo in the header
* Update for designers/developers container to match spec padding
* Fix date modified to use correct font-set and margins

**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)

** File names and hierarchies are in keeping with our norms:
* Interfaces start with 'I' followed by a capital letter and camel case (IInterfaceExample) and are descriptive
* Subjects are suffixed with 'Subj' (ex: thisIsAnExampleSubj)
* Subscriptions are suffixed with 'Sub' (ex: thisIsAnExampleSub)
* Observables ere suffixed with 'Obs$' (ex: thisIsAnExampleObs$)
* Class and variable names are camel case
* Class names should start with a capital letter (i.e. ExampleClass)
* Variable names should start with a lower case letter (i.e thisIsAnExampleVariable)
* All caps and underscores are used for exported constants (THIS_IS_A_CONSTANT)
* Names are all spelled correctly
* ngOnInit and constructor is removed when not used
* ':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?

**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.