### PR TITLE
BUG: selector mixin change

### DIFF
--- a/core-library/component-styling/banner/_banner.scss
+++ b/core-library/component-styling/banner/_banner.scss
@@ -97,7 +97,7 @@
 }
 
 @mixin layout {
-  @include size.selector(large) {
+  @include size.select(large) {
     @include large-styles();
 
     .small {
@@ -105,7 +105,7 @@
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include small-styles();
 
     .large {
@@ -208,8 +208,12 @@
   }
 
   @keyframes fadeout {
-    0% { opacity: 1 };
-    100% { opacity: 0 };
+    0% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
   }
 
   .noDisplay {

--- a/core-library/component-styling/breadcrumb/_breadcrumb.scss
+++ b/core-library/component-styling/breadcrumb/_breadcrumb.scss
@@ -217,7 +217,7 @@
     position: absolute;
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include size-sm();
 
     .large {
@@ -225,7 +225,7 @@
     }
   }
 
-  @include size.selector(large) {
+  @include size.select(large) {
     @include size-lg();
 
     .small {

--- a/core-library/component-styling/checkbox/_checkbox.scss
+++ b/core-library/component-styling/checkbox/_checkbox.scss
@@ -1,11 +1,11 @@
-@use "../../util/color"as color;
-@use "../../util/theme"as theme;
-@use "../../util/device"as device;
-@use "../../util/size"as size;
-@use "../../tokens/template-const"as template-const;
-@use "../../tokens/sizes"as token-size;
-@use "../../typography/typography"as typography;
-@use "../../tokens/text"as text;
+@use "../../util/color" as color;
+@use "../../util/theme" as theme;
+@use "../../util/device" as device;
+@use "../../util/size" as size;
+@use "../../tokens/template-const" as template-const;
+@use "../../tokens/sizes" as token-size;
+@use "../../typography/typography" as typography;
+@use "../../tokens/text" as text;
 @use "../../util/accessibility" as a11y;
 @use "sass:map";
 
@@ -48,7 +48,7 @@
   }
 
   .makeBold {
-    font-family: 'Inter', sans-serif;
+    font-family: "Inter", sans-serif;
     color: var(--text-primary);
     font-weight: bold;
   }
@@ -66,11 +66,11 @@
     margin-top: token-size.$fixed-8;
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include size-sm();
   }
 
-  @include size.selector(large) {
+  @include size.select(large) {
     .small {
       @include size-sm();
     }

--- a/core-library/component-styling/date-picker/_date-picker.scss
+++ b/core-library/component-styling/date-picker/_date-picker.scss
@@ -1,11 +1,11 @@
-@use '../../util/theme'as theme;
-@use '../../util/size'as size;
-@use '../../tokens/sizes'as token-size;
-@use '../../tokens/template-const';
-@use '../../typography/typography'as typography;
-@use '../../tokens/text'as text;
+@use "../../util/theme" as theme;
+@use "../../util/size" as size;
+@use "../../tokens/sizes" as token-size;
+@use "../../tokens/template-const";
+@use "../../typography/typography" as typography;
+@use "../../tokens/text" as text;
 @use "../../util/accessibility" as a11y;
-@use 'sass:map';
+@use "sass:map";
 
 @mixin selector {
   ircc-cl-lib-date-picker#{template-const.$escape} {
@@ -54,7 +54,6 @@
 }
 
 @mixin size-small() {
-
   @media (max-width: 530px) {
     .all-select-container {
       .select-year {
@@ -90,24 +89,22 @@
       }
     }
   }
-
 }
 
 @mixin layout {
-
-  @include size.selector(large) {
+  @include size.select(large) {
     @include size-large();
 
     .small {
-      @include size-small()
+      @include size-small();
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include size-small();
 
     .large {
-      @include size-large()
+      @include size-large();
     }
   }
 
@@ -149,7 +146,6 @@
     }
   }
 
-
   .date-form {
     display: flex;
     flex-wrap: nowrap;
@@ -170,7 +166,7 @@
 
   select::placeholder {
     text-align: left;
-    margin-left: 0px
+    margin-left: 0px;
   }
 
   ::-webkit-input-placeholder {

--- a/core-library/component-styling/dropdown/_dropdown.scss
+++ b/core-library/component-styling/dropdown/_dropdown.scss
@@ -66,14 +66,14 @@
 }
 
 @mixin layout {
-  @include size.selector(large) {
+  @include size.select(large) {
     @include size-large();
     .small {
       @include size-small();
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include size-small();
     .large {
       @include size-large();

--- a/core-library/component-styling/error/_error.scss
+++ b/core-library/component-styling/error/_error.scss
@@ -33,8 +33,6 @@ $selectors: "ircc-cl-lib-error";
       top: 4px;
       bottom: 0px;
     }
-
-    ;
   }
 
   .additionalError {
@@ -42,8 +40,6 @@ $selectors: "ircc-cl-lib-error";
       top: 8px;
       left: 20px;
     }
-
-    ;
   }
 }
 
@@ -70,7 +66,7 @@ $selectors: "ircc-cl-lib-error";
 }
 
 @mixin layout {
-  @include size.selector(large) {
+  @include size.select(large) {
     @include large-styles();
 
     .small {
@@ -78,7 +74,7 @@ $selectors: "ircc-cl-lib-error";
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include small-styles();
 
     .large {

--- a/core-library/component-styling/flyout-option/_flyout-option.scss
+++ b/core-library/component-styling/flyout-option/_flyout-option.scss
@@ -73,14 +73,14 @@
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include small-styles;
     .large {
       @include large-styles;
     }
   }
 
-  @include size.selector(large) {
+  @include size.select(large) {
     @include large-styles;
     .small {
       @include small-styles;

--- a/core-library/component-styling/flyout/_flyout.scss
+++ b/core-library/component-styling/flyout/_flyout.scss
@@ -74,14 +74,14 @@
     }
   }
 
-  @include size.selector(large) {
+  @include size.select(large) {
     @include large-styles;
     .small {
       @include small-styles;
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include small-styles;
     .large {
       @include large-styles;

--- a/core-library/component-styling/icon-button/_icon-button.scss
+++ b/core-library/component-styling/icon-button/_icon-button.scss
@@ -106,11 +106,11 @@
         }
       }
 
-      @include size.selector(large) {
+      @include size.select(large) {
         @include primary-lg;
       }
 
-      @include size.selector(small) {
+      @include size.select(small) {
         @include primary-sm;
       }
     }
@@ -124,11 +124,11 @@
         @include critical-sm;
       }
 
-      @include size.selector(large) {
+      @include size.select(large) {
         @include critical-lg;
       }
 
-      @include size.selector(small) {
+      @include size.select(small) {
         @include critical-sm;
       }
     }
@@ -148,11 +148,11 @@
         }
       }
 
-      @include size.selector(large) {
+      @include size.select(large) {
         @include primary-lg;
       }
 
-      @include size.selector(small) {
+      @include size.select(small) {
         @include primary-sm;
       }
     }

--- a/core-library/component-styling/indicator/_indicator.scss
+++ b/core-library/component-styling/indicator/_indicator.scss
@@ -243,7 +243,7 @@ $color: grey, red, orange, blue, green, purple, teal, navy;
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include size-sm();
 
     .large {
@@ -251,7 +251,7 @@ $color: grey, red, orange, blue, green, purple, teal, navy;
     }
   }
 
-  @include size.selector(large) {
+  @include size.select(large) {
     @include size-lg();
 
     .small {

--- a/core-library/component-styling/input-component/_input-component.scss
+++ b/core-library/component-styling/input-component/_input-component.scss
@@ -67,14 +67,14 @@
     user-select: none;
   }
 
-  @include size.selector(large) {
+  @include size.select(large) {
     @include size-large();
     .small {
       @include size-small();
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include size-small();
     .large {
       @include size-large();

--- a/core-library/component-styling/label/_label-component.scss
+++ b/core-library/component-styling/label/_label-component.scss
@@ -1,22 +1,22 @@
-@use '../../util/color' as color;
-@use '../../util/theme' as theme;
-@use '../../util/device' as device;
-@use '../../util/size' as size;
-@use '../../tokens/template-const' as template-const;
-@use '../../tokens/sizes' as token-size;
-@use '../../typography/typography' as typography;
-@use '../../tokens/text' as text;
-@use 'sass:map';
+@use "../../util/color" as color;
+@use "../../util/theme" as theme;
+@use "../../util/device" as device;
+@use "../../util/size" as size;
+@use "../../tokens/template-const" as template-const;
+@use "../../tokens/sizes" as token-size;
+@use "../../typography/typography" as typography;
+@use "../../tokens/text" as text;
+@use "sass:map";
 
 @mixin selector {
   ircc-cl-lib-label#{template-const.$escape} {
-      @content;
+    @content;
   }
 }
 
 @mixin create {
   @include selector() {
-      @include layout();
+    @include layout();
   }
 }
 
@@ -54,7 +54,6 @@
 }
 
 @mixin size-small() {
-
   .label {
     @include typography.fontSet(heading, 6, emphasis);
   }
@@ -71,7 +70,6 @@
   .required-star {
     font-size: 12px;
   }
-
 }
 
 @mixin layout {
@@ -85,7 +83,7 @@
     display: grid;
     position: relative;
 
-    .label_field_container{
+    .label_field_container {
       display: flex;
       word-break: break-all;
       white-space: normal;
@@ -93,43 +91,43 @@
         display: flex;
       }
     }
-      .label {
-        display: flex;
-      }
-      .input-desc {
-        word-break: break-all;
-        white-space: normal;
-        margin: 4px 0px 0px 0px;
-      }
+    .label {
+      display: flex;
+    }
+    .input-desc {
+      word-break: break-all;
+      white-space: normal;
+      margin: 4px 0px 0px 0px;
+    }
 
-      .input-hint {
-        word-break: break-all;
-        white-space: normal;
-        color: var(--text-placeholder)
+    .input-hint {
+      word-break: break-all;
+      white-space: normal;
+      color: var(--text-placeholder);
+    }
+    .required-field-container {
+      display: flex;
+      .required-star {
+        color: var(--critical-text);
+        font-weight: 400;
+        line-height: 16px;
+        justify-self: flex-start;
+        margin-right: 5px;
       }
-      .required-field-container {
-        display: flex;
-        .required-star {
-          color: var(--critical-text);
-          font-weight: 400;
-          line-height: 16px;
-          justify-self:flex-start;
-          margin-right: 5px;
-        }
-      }
-  }
-
-  @include size.selector(large) {
-    @include size-large();
-    .small {
-      @include size-small()
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(large) {
+    @include size-large();
+    .small {
+      @include size-small();
+    }
+  }
+
+  @include size.select(small) {
     @include size-small();
     .large {
-      @include size-large()
+      @include size-large();
     }
   }
 

--- a/core-library/component-styling/progress-indicator/_progress-indicator.scss
+++ b/core-library/component-styling/progress-indicator/_progress-indicator.scss
@@ -22,146 +22,149 @@
 }
 
 @mixin large-styles() {
-    button.tags-btn {
-        @include typography.fontSet(body, 3, regular);
-        &:where([selected])::after {
-            transform: translateY(sizes.$fixed-0);
-        }
-    }
-    button.tags-btn-plus {
-        @include typography.fontSet(body, 3, regular); 
-        padding-bottom: 4px;
-    }
-    .stepTitle {
-        @include typography.fontSet(heading, 5, regular);
-        margin-bottom: 8px;
+  button.tags-btn {
+    @include typography.fontSet(body, 3, regular);
+    &:where([selected])::after {
+      transform: translateY(sizes.$fixed-0);
     }
   }
+  button.tags-btn-plus {
+    @include typography.fontSet(body, 3, regular);
+    padding-bottom: 4px;
+  }
+  .stepTitle {
+    @include typography.fontSet(heading, 5, regular);
+    margin-bottom: 8px;
+  }
+}
 
 @mixin small-styles() {
-    button.tags-btn {
-        @include typography.fontSet(body, 4, regular);
-        &:where([selected])::after {
-            transform: translateY(sizes.$fixed-0);
-        }
+  button.tags-btn {
+    @include typography.fontSet(body, 4, regular);
+    &:where([selected])::after {
+      transform: translateY(sizes.$fixed-0);
     }
-    button.tags-btn-plus {
-        @include typography.fontSet(body, 4, regular);
-        padding-bottom: 4px;
+  }
+  button.tags-btn-plus {
+    @include typography.fontSet(body, 4, regular);
+    padding-bottom: 4px;
+  }
+  .stepTitle {
+    @include typography.fontSet(heading, 6, regular);
+    margin-bottom: 4px;
+  }
+}
+
+@mixin layout {
+  .horizontal {
+    padding-top: 3.5px;
+    padding-left: 5.5px;
+    display: flex;
+    overflow-x: auto;
+    justify-content: space-between;
+    .container-plus-line {
+      width: 100%;
     }
-    .stepTitle {
-        @include typography.fontSet(heading, 6, regular);
-        margin-bottom: 4px;
+    .line {
+      border-bottom-style: solid;
+      border-bottom-width: 1px;
+      border-bottom-color: var(--divider);
+      width: 100%;
+    }
+    .green-line {
+      border-bottom-style: solid;
+      border-bottom-width: 1px;
+      border-bottom-color: var(--success-border);
+      width: 100%;
+    }
+  }
+  .vertical {
+    padding-top: 3.5px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+    .container-plus-line {
+      height: 100%;
+      display: flex;
+      flex-direction: row-reverse;
+      justify-content: flex-end;
+    }
+    .line {
+      border-left-style: solid;
+      border-left-width: 1px;
+      border-left-color: var(--divider);
+      margin-right: 16px;
+      height: 100%;
+      justify-self: flex-start;
+    }
+    .green-line {
+      border-left-style: solid;
+      border-left-width: 1px;
+      border-left-color: var(--success-border);
+      margin-right: 16px;
+    }
+  }
+  .container {
+    padding: 0;
+    margin-right: 16px;
+    margin-bottom: 16px;
+
+    .except-line {
+      display: flex;
+      flex-direction: column;
+      align-items: start;
+    }
+
+    @include device.if-hover {
+      background: var(--generic-hover);
+      border-radius: 4px;
+      outline: 2px solid var(--generic-hover);
+      &:where([selected])::after {
+        background: var(--generic-hover);
+      }
+    }
+    &:active {
+      background: var(--generic-active);
+      border-radius: 4px;
+      outline: 2px solid var(--generic-active);
+      &:where([selected])::after {
+        background: var(--generic-active);
+      }
+    }
+    &:disabled {
+      background: var(--surface1);
+      outline: 2px solid var(--surface1);
+      .stepTitle {
+        color: var(--text-disabled);
+      }
+    }
+    &:focus {
+      border-radius: 4px;
     }
   }
 
-@mixin layout {
-    .horizontal {
-        padding-top: 3.5px;
-        padding-left: 5.5px;
-        display: flex;
-        overflow-x: auto;
-        justify-content: space-between;
-        .container-plus-line {
-            width: 100%;
-        }
-        .line {
-            border-bottom-style: solid;
-            border-bottom-width: 1px;
-            border-bottom-color: var(--divider);
-            width: 100%;
-        }
-        .green-line {
-            border-bottom-style: solid;
-            border-bottom-width: 1px;
-            border-bottom-color: var(--success-border);
-            width: 100%;
-        }
-    }
-    .vertical {
-        padding-top: 3.5px;
-        overflow-y: auto;
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-        height: 100%;
-        .container-plus-line {
-            height: 100%;
-            display: flex;
-            flex-direction: row-reverse;
-            justify-content: flex-end;
-        }
-        .line {
-            border-left-style: solid;
-            border-left-width: 1px;
-            border-left-color: var(--divider);
-            margin-right: 16px;
-            height: 100%;
-            justify-self: flex-start;
-        }
-        .green-line {
-            border-left-style: solid;
-            border-left-width: 1px;
-            border-left-color: var(--success-border);
-            margin-right: 16px;
-        }
-    }
-    .container {
-        padding: 0;
-        margin-right: 16px;
-        margin-bottom: 16px;
+  button.tags-btn {
+    color: var(--text-secondary);
+    padding: 0 0 0 2px;
+    background-color: transparent;
+    pointer-events: none;
+  }
+  button.tags-btn-plus {
+    color: var(--text-secondary);
+    padding: 0 0 0 2px;
+    background-color: transparent;
+    pointer-events: none;
+  }
+  .stepTitle {
+    padding-left: 2px;
+    margin-top: 4px;
+    color: var(--text-primary);
+    white-space: nowrap;
+  }
 
-        .except-line {
-            display: flex;
-            flex-direction: column;
-            align-items: start;
-        }
-
-        @include device.if-hover {
-            background: var(--generic-hover);
-            border-radius: 4px;
-            outline: 2px solid var(--generic-hover);
-            &:where([selected])::after {
-                background: var(--generic-hover);
-            }
-        } &:active {
-            background: var(--generic-active);
-            border-radius: 4px;
-            outline: 2px solid var(--generic-active);
-            &:where([selected])::after {
-                background: var(--generic-active);
-            }
-        } &:disabled {
-            background: var(--surface1);
-            outline: 2px solid var(--surface1);
-            .stepTitle {
-                color: var(--text-disabled);
-            }
-        } &:focus {
-            border-radius: 4px;
-        }
-    }
-    
-    button.tags-btn {
-        color: var(--text-secondary);
-        padding: 0 0 0 2px;
-        background-color: transparent;
-        pointer-events: none;
-    }
-    button.tags-btn-plus {
-        color: var(--text-secondary);
-        padding: 0 0 0 2px;
-        background-color: transparent;
-        pointer-events: none;
-    }
-    .stepTitle {
-        padding-left: 2px;
-        margin-top: 4px;
-        color: var(--text-primary);
-        white-space: nowrap;
-    }
-
-  @include size.selector(large) {
+  @include size.select(large) {
     @include large-styles();
 
     .small {
@@ -169,11 +172,11 @@
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include small-styles();
 
     .large {
       @include large-styles();
     }
-}
+  }
 }

--- a/core-library/component-styling/progress-tags/_progress-tags.scss
+++ b/core-library/component-styling/progress-tags/_progress-tags.scss
@@ -62,14 +62,14 @@
 }
 
 @mixin layout {
-  @include size.selector(large) {
+  @include size.select(large) {
     @include large-styles();
     .small {
       @include small-styles();
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include small-styles();
     .large {
       @include large-styles();

--- a/core-library/component-styling/radio/_radio.scss
+++ b/core-library/component-styling/radio/_radio.scss
@@ -1,13 +1,13 @@
-@use '../../util/color'as color;
-@use '../../util/theme'as theme;
-@use '../../util/device'as device;
-@use '../../util/size'as size;
-@use '../../tokens/template-const'as template-const;
-@use '../../tokens/sizes'as token-size;
-@use '../../typography/typography'as typography;
-@use '../../tokens/text'as text;
+@use "../../util/color" as color;
+@use "../../util/theme" as theme;
+@use "../../util/device" as device;
+@use "../../util/size" as size;
+@use "../../tokens/template-const" as template-const;
+@use "../../tokens/sizes" as token-size;
+@use "../../typography/typography" as typography;
+@use "../../tokens/text" as text;
 @use "../../util/accessibility" as a11y;
-@use 'sass:map';
+@use "sass:map";
 
 @mixin selector {
   ircc-cl-lib-radio-input#{template-const.$escape} {
@@ -62,7 +62,7 @@
     font-size: 16px;
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include small-styles();
 
     .large {
@@ -70,7 +70,7 @@
     }
   }
 
-  @include size.selector(large) {
+  @include size.select(large) {
     @include large-styles();
 
     .small {

--- a/core-library/component-styling/select/_select-component.scss
+++ b/core-library/component-styling/select/_select-component.scss
@@ -71,7 +71,7 @@ $selectors: "ircc-cl-lib-select";
 }
 
 @mixin layout {
-  @include size.selector(large) {
+  @include size.select(large) {
     @include size-large();
 
     .small {
@@ -79,7 +79,7 @@ $selectors: "ircc-cl-lib-select";
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include size-small();
 
     .large {

--- a/core-library/component-styling/spinner/_spinner.scss
+++ b/core-library/component-styling/spinner/_spinner.scss
@@ -52,7 +52,7 @@ $selectors: "ircc-cl-lib-spinner";
       border-radius: 50%;
       .spinner-icon {
         align-self: center;
-        >#ds-icon-container>span>svg {
+        > #ds-icon-container > span > svg {
           width: 40px;
           height: 40px;
         }
@@ -83,7 +83,7 @@ $selectors: "ircc-cl-lib-spinner";
       height: 28px;
       border-radius: 50%;
       .spinner-icon {
-        >#ds-icon-container>span>svg {
+        > #ds-icon-container > span > svg {
           width: 14px;
           height: 16px;
         }
@@ -156,14 +156,14 @@ $selectors: "ircc-cl-lib-spinner";
     color: var(--text-placeholder);
   }
 
-  @include size.selector(large) {
+  @include size.select(large) {
     @include size-large();
     .small {
       @include size-small();
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include size-small();
     .large {
       @include size-large();
@@ -182,14 +182,14 @@ $selectors: "ircc-cl-lib-spinner";
         border-radius: 50%;
         .spinner-icon {
           align-self: flex-end;
-          >#ds-icon-container>span>svg {
+          > #ds-icon-container > span > svg {
             width: 12px;
             height: 12px;
           }
         }
       }
     }
-    
+
     .loading-icon {
       width: 20px;
       height: 20px;

--- a/core-library/component-styling/tabs/_tabs.scss
+++ b/core-library/component-styling/tabs/_tabs.scss
@@ -51,14 +51,14 @@ $selectors: "ircc-cl-lib-tabs";
     overflow: visible;
   }
 
-  @include size.selector(large) {
+  @include size.select(large) {
     @include size-large();
     .small {
       @include size-small();
     }
   }
 
-  @include size.selector(small) {
+  @include size.select(small) {
     @include size-small();
     .large {
       @include size-large();

--- a/core-library/component-styling/textarea/_textarea.scss
+++ b/core-library/component-styling/textarea/_textarea.scss
@@ -1,12 +1,12 @@
-@use '../../util/color' as color;
-@use '../../util/theme' as theme;
-@use '../../util/device' as device;
-@use '../../util/size' as size;
-@use '../../tokens/template-const' as template-const;
-@use '../../tokens/sizes' as token-size;
-@use '../../typography/typography' as typography;
-@use '../../tokens/text' as text;
-@use 'sass:map';
+@use "../../util/color" as color;
+@use "../../util/theme" as theme;
+@use "../../util/device" as device;
+@use "../../util/size" as size;
+@use "../../tokens/template-const" as template-const;
+@use "../../tokens/sizes" as token-size;
+@use "../../typography/typography" as typography;
+@use "../../tokens/text" as text;
+@use "sass:map";
 
 @mixin selector {
   ircc-cl-lib-textarea#{template-const.$escape} {
@@ -21,10 +21,9 @@
 }
 
 @mixin size-large() {
-
   .textarea-field {
     min-height: 78px;
-    padding: 14px 16px 14px 20px; 
+    padding: 14px 16px 14px 20px;
     margin-top: 8px;
     font-size: 16px;
     line-height: 24px;
@@ -38,10 +37,9 @@
 }
 
 @mixin size-small() {
-
   .textarea-field {
     min-height: 62px;
-    padding: 10px 16px 10px 14px; 
+    padding: 10px 16px 10px 14px;
     margin-top: 4px;
     font-size: 14px;
     line-height: 20px;
@@ -59,7 +57,7 @@
 }
 
 @mixin at-resize($value: none) {
-  .resize-#{$value}{
+  .resize-#{$value} {
     textarea {
       resize: $value;
     }
@@ -67,18 +65,17 @@
 }
 
 @mixin layout {
-
-  @include size.selector(large) {
+  @include size.select(large) {
     @include size-large();
     .small {
-        @include size-small()
+      @include size-small();
     }
   }
-    
-  @include size.selector(small) {
+
+  @include size.select(small) {
     @include size-small();
     .large {
-      @include size-large()
+      @include size-large();
     }
   }
 
@@ -99,17 +96,14 @@
         color: var(--warning-text);
       }
 
-
       textarea {
         display: block;
         box-sizing: border-box;
 
         &:disabled {
-
           &::placeholder {
-            color: var(--text-disabled)
+            color: var(--text-disabled);
           }
-
         }
       }
     }

--- a/core-library/tokens/button/_button-const.scss
+++ b/core-library/tokens/button/_button-const.scss
@@ -1,52 +1,52 @@
-@use '../../util/theme' as theme;
-@use '../../util/size' as size;
-@use '../sizes' as token-size;
-@use '../template-const';
-$selectors: 'button';
+@use "../../util/theme" as theme;
+@use "../../util/size" as size;
+@use "../sizes" as token-size;
+@use "../template-const";
+$selectors: "button";
 
 @mixin button-size-padding {
-    @include size.selector(small) {
-        padding: token-size.$small-padding;
-    }
+  @include size.select(small) {
+    padding: token-size.$small-padding;
+  }
 
-    @include size.selector(large) {
-        padding: token-size.$large-padding;
-    }
+  @include size.select(large) {
+    padding: token-size.$large-padding;
+  }
 }
 
 @mixin selectors {
-        #{$selectors}#{template-const.$escape} {
-            @content;
-        }
+  #{$selectors}#{template-const.$escape} {
+    @content;
+  }
 }
 
 @mixin layout {
-    border-radius: token-size.$border-radius;
-    border-style: none;
-    justify-content: center;
-    cursor: pointer;
+  border-radius: token-size.$border-radius;
+  border-style: none;
+  justify-content: center;
+  cursor: pointer;
 
-    @include button-size();
-    @include button-size-padding();
+  @include button-size();
+  @include button-size-padding();
 
-    color: var(--text);
+  color: var(--text);
 }
 
 @mixin layout-round {
-    border-radius: token-size.$border-radius-circle;
-    border-style: none;
-    justify-content: center;
-    aspect-ratio: 1 / 1;
-    @include button-size();
+  border-radius: token-size.$border-radius-circle;
+  border-style: none;
+  justify-content: center;
+  aspect-ratio: 1 / 1;
+  @include button-size();
 
-    color: var(--text);
+  color: var(--text);
 }
 @mixin button-size {
-    @include size.selector(small) {
-        @extend .h6;
-    }
+  @include size.select(small) {
+    @extend .h6;
+  }
 
-    @include size.selector(large) {
-        @extend .h5;
-    }
+  @include size.select(large) {
+    @extend .h5;
+  }
 }

--- a/core-library/tokens/button/_nav.scss
+++ b/core-library/tokens/button/_nav.scss
@@ -1,77 +1,76 @@
-@use '../../util/theme';
-@use './button-const';
-@use './plain';
-@use '../sizes';
-@use '../template-const';
-@use '../../util/device';
-@use '../../util/color';
-@use '../../util/size';
+@use "../../util/theme";
+@use "./button-const";
+@use "./plain";
+@use "../sizes";
+@use "../template-const";
+@use "../../util/device";
+@use "../../util/color";
+@use "../../util/size";
 
 @mixin selectors {
-    a:any-link, #{button-const.$selectors}:where(:not([category])) {
-        &#{template-const.$escape}:where(nav *) {
-            @content;
-        }
+  a:any-link,
+  #{button-const.$selectors}:where(:not([category])) {
+    &#{template-const.$escape}:where(nav *) {
+      @content;
     }
+  }
 }
 
 @mixin create {
-    @include selectors() {
-        @include layout();
-        @include layout-tab();
-    }
+  @include selectors() {
+    @include layout();
+    @include layout-tab();
+  }
 }
 
 @mixin layout-tab() {
-    background: var(--surface1);
-    --text: var(--text-secondary);
-    text-decoration: none;
-    position: relative;
-    display: inline-block;
-    @include size.selector(small) {
-        &:where([selected])::after {
-            transform: translateY(sizes.$fixed-8);
-        }
-    }
-    @include size.selector(large) {
-        &:where([selected])::after {
-            transform: translateY(sizes.$fixed-12);
-        }
-    }
+  background: var(--surface1);
+  --text: var(--text-secondary);
+  text-decoration: none;
+  position: relative;
+  display: inline-block;
+  @include size.select(small) {
     &:where([selected])::after {
-        content: '';
-        height:sizes.$fixed-4;
-        background: var(--navigation);
-        display: block;
+      transform: translateY(sizes.$fixed-8);
     }
-    &:where([selected]){
-        --text: var(--text-primary);
+  }
+  @include size.select(large) {
+    &:where([selected])::after {
+      transform: translateY(sizes.$fixed-12);
     }
+  }
+  &:where([selected])::after {
+    content: "";
+    height: sizes.$fixed-4;
+    background: var(--navigation);
+    display: block;
+  }
+  &:where([selected]) {
+    --text: var(--text-primary);
+  }
 
-    @include device.if-hover() {
-        background: var(--generic-hover);
-        &:where([selected])::after {
-            background: var(--navigation-hover);
-        }
+  @include device.if-hover() {
+    background: var(--generic-hover);
+    &:where([selected])::after {
+      background: var(--navigation-hover);
     }
-    &:active {
-        background: var(--generic-active);
-        &:where([selected])::after {
-            background: var(--navigation-hover);
-        }
+  }
+  &:active {
+    background: var(--generic-active);
+    &:where([selected])::after {
+      background: var(--navigation-hover);
     }
-    &:disabled {
-        background: var(--surface1);
-        color: var(--text-disabled);
-        &:where([selected])::after {
-            background: var(--navigation-disabled);
-        }
+  }
+  &:disabled {
+    background: var(--surface1);
+    color: var(--text-disabled);
+    &:where([selected])::after {
+      background: var(--navigation-disabled);
     }
-
-
+  }
 }
 
 @mixin layout() {
-    @include button-const.layout();
-    @include layout-tab();
+  @include button-const.layout();
+  @include layout-tab();
 }

--- a/core-library/tokens/checkbox/_checkbox.scss
+++ b/core-library/tokens/checkbox/_checkbox.scss
@@ -1,185 +1,183 @@
-@use '../../util/color' as color;
-@use '../../util/theme' as theme;
-@use '../../util/device' as device;
-@use '../../util/size' as size;
-@use '../template-const' as template-const;
-@use '../sizes' as token-size;
-@use '../../typography/typography' as typography;
-@use '../text' as text;
-@use 'sass:map';
+@use "../../util/color" as color;
+@use "../../util/theme" as theme;
+@use "../../util/device" as device;
+@use "../../util/size" as size;
+@use "../template-const" as template-const;
+@use "../sizes" as token-size;
+@use "../../typography/typography" as typography;
+@use "../text" as text;
+@use "sass:map";
 
 @mixin selector {
-    input[type='checkbox']#{template-const.$escape} {
-        @content;
-    }
+  input[type="checkbox"]#{template-const.$escape} {
+    @content;
+  }
 }
 
 @mixin create {
-    @include selector() {
-        @include layout();
-    }
+  @include selector() {
+    @include layout();
+  }
 }
 
 @mixin layout {
-    border-radius: token-size.$border-radius;
-    appearance: none;
-    margin-right: token-size.$fixed-12;
-    margin-left: 0;
-    box-sizing: border-box;
-    box-shadow: token-size.$border-style;
-    vertical-align: middle;
-    cursor: pointer;
-    display: inline-flex;
-    padding: 0;
+  border-radius: token-size.$border-radius;
+  appearance: none;
+  margin-right: token-size.$fixed-12;
+  margin-left: 0;
+  box-sizing: border-box;
+  box-shadow: token-size.$border-style;
+  vertical-align: middle;
+  cursor: pointer;
+  display: inline-flex;
+  padding: 0;
 
-    @include checkbox-size();
+  @include checkbox-size();
+
+  & + label {
+    padding-left: 8px;
+    width: 130px;
+    height: 20px;
+    font-style: normal;
+    @include typography.fontSet(body, 3, regular);
+    color: var(--text-primary);
+    flex: none;
+    order: 0;
+    flex-grow: 1;
+  }
+
+  @include device.if-hover {
+    color: var(--formcontrol-hover);
+  }
+  &:active {
+    background-color: var(--generic-active);
+  }
+
+  &:disabled {
+    --border: var(--border-disabled);
+    cursor: not-allowed;
 
     & + label {
-        padding-left: 8px;
-        width: 130px;
-        height: 20px;
-        font-style: normal;
-        @include typography.fontSet(body, 3, regular);
-        color: var(--text-primary);
-        flex: none;
-        order: 0;
-        flex-grow: 1;
+      color: var(--text-disabled);
     }
 
-    @include device.if-hover {
-        color: var(--formcontrol-hover);
-    }
     &:active {
-        background-color: var(--generic-active);
+      --border: var(--border-disabled);
+      background-color: var(--surface1);
+    }
+  }
+
+  &:checked,
+  &:indeterminate {
+    @include device.if-hover {
+      background-color: var(--formcontrol-hover);
     }
 
+    &:active {
+      background-color: var(--formcontrol-hover);
+    }
     &:disabled {
-        --border: var(--border-disabled);
-        cursor: not-allowed;
-
-        & + label {
-            color: var(--text-disabled);
-        }
-
-        &:active {
-            --border: var(--border-disabled);
-            background-color: var(--surface1);
-        }
+      background-color: var(--formcontrol-disabled);
     }
+  }
 
-    &:checked,
-    &:indeterminate {
-        @include device.if-hover {
-            background-color: var(--formcontrol-hover);
-        }
-
-        &:active {
-            background-color: var(--formcontrol-hover);
-        }
-        &:disabled {
-            background-color: var(--formcontrol-disabled);
-        }
-    }
-
-    @include checked();
-    @include invalid();
-    @include mixed-state();
+  @include checked();
+  @include invalid();
+  @include mixed-state();
 }
 
 @mixin checked {
-    &:checked {
-        box-shadow: none;
-        background-color: var(--formcontrol);
+  &:checked {
+    box-shadow: none;
+    background-color: var(--formcontrol);
 
-        @include create-icon('\f00c');
-    }
+    @include create-icon("\f00c");
+  }
 }
 
 @mixin invalid {
-    &:invalid, &.ng-invalid.ng-touched, &.error {
-        --border: var(--critical-border);
-        background-color: var(--critical-background-weak);
+  &:invalid,
+  &.ng-invalid.ng-touched,
+  &.error {
+    --border: var(--critical-border);
+    background-color: var(--critical-background-weak);
 
-        @include device.if-hover {
-            --border: var(--critical-border-hover);
-            background-color: var(--critical-background-weak-hover);
-        }
-
-        &:active {
-            --border: var(--critical-border-hover);
-            background-color: var(--critical-background-weak-active);
-        }
-        &:indeterminate,
-        &:checked {
-            box-shadow: none;
-            background-color: var(--critical-background);
-
-            @include device.if-hover {
-                background-color: var(--critical-background-hover);
-            }
-
-            &:active {
-                background-color: var(--critical-background-active);
-            }
-        }
+    @include device.if-hover {
+      --border: var(--critical-border-hover);
+      background-color: var(--critical-background-weak-hover);
     }
+
+    &:active {
+      --border: var(--critical-border-hover);
+      background-color: var(--critical-background-weak-active);
+    }
+    &:indeterminate,
+    &:checked {
+      box-shadow: none;
+      background-color: var(--critical-background);
+
+      @include device.if-hover {
+        background-color: var(--critical-background-hover);
+      }
+
+      &:active {
+        background-color: var(--critical-background-active);
+      }
+    }
+  }
 }
 
 @mixin mixed-state {
-    &:indeterminate,
-    &.mixed:checked {
-        box-shadow: none;
-        background-color: var(--formcontrol);
+  &:indeterminate,
+  &.mixed:checked {
+    box-shadow: none;
+    background-color: var(--formcontrol);
 
-        @include create-icon('\f068');
-    }
+    @include create-icon("\f068");
+  }
 }
 
 @mixin checkbox-size {
-    @include size.selector(small) {
-        width: token-size.$relative-1-25;
-        height: token-size.$relative-1-25;
+  @include size.select(small) {
+    width: token-size.$relative-1-25;
+    height: token-size.$relative-1-25;
 
-        &:checked::before,
-        &:indeterminate::before {
-            @include icon-size(
-                token-size.$relative-0-875,
-                token-size.$relative-1,
-                2
-            );
-        }
+    &:checked::before,
+    &:indeterminate::before {
+      @include icon-size(token-size.$relative-0-875, token-size.$relative-1, 2);
     }
+  }
 
-    @include size.selector(large) {
-        width: token-size.$relative-1-5;
-        height: token-size.$relative-1-5;
+  @include size.select(large) {
+    width: token-size.$relative-1-5;
+    height: token-size.$relative-1-5;
 
-        &:checked::before,
-        &:indeterminate::before {
-            @include icon-size(
-                token-size.$relative-1-125,
-                token-size.$relative-1-25,
-                1
-            );
-        }
+    &:checked::before,
+    &:indeterminate::before {
+      @include icon-size(
+        token-size.$relative-1-125,
+        token-size.$relative-1-25,
+        1
+      );
     }
+  }
 }
 
 @mixin icon-size($width, $height, $level) {
-    width: $width;
-    height: $height;
-    left: calc(50% - $width / 2);
-    top: calc(50% - $height / 2);
-    font-size: map.get(text.$body, level, $level, font-size);
-    line-height: map.get(text.$body, level, $level, font-size);
+  width: $width;
+  height: $height;
+  left: calc(50% - $width / 2);
+  top: calc(50% - $height / 2);
+  font-size: map.get(text.$body, level, $level, font-size);
+  line-height: map.get(text.$body, level, $level, font-size);
 }
 
 @mixin create-icon($content) {
-    &::before {
-        content: $content;
-        color: var(--surface1);
-        position: relative;
+  &::before {
+    content: $content;
+    color: var(--surface1);
+    position: relative;
 
-        @extend .fa-regular;
-    }
+    @extend .fa-regular;
+  }
 }

--- a/core-library/tokens/input/_input-const.scss
+++ b/core-library/tokens/input/_input-const.scss
@@ -1,79 +1,79 @@
-@use '../../util/color' as color;
-@use '../../util/theme' as theme;
-@use '../template-const' as template-const;
-@use '../sizes' as sizes;
-@use '../../util/device' as device;
-@use '../../util/size' as size;
+@use "../../util/color" as color;
+@use "../../util/theme" as theme;
+@use "../template-const" as template-const;
+@use "../sizes" as sizes;
+@use "../../util/device" as device;
+@use "../../util/size" as size;
 
 @mixin common {
-    width: 100%;
-    border-style: solid;
-    border-width: sizes.$fixed-1;
-    border-radius: sizes.$border-radius;
-    color: var(--text-primary);
+  width: 100%;
+  border-style: solid;
+  border-width: sizes.$fixed-1;
+  border-radius: sizes.$border-radius;
+  color: var(--text-primary);
 
-    @include size.selector(small) {
-        @extend .body3;
-    }
+  @include size.select(small) {
+    @extend .body3;
+  }
 
-    @include size.selector(large) {
-        @extend .body2;
-    }
+  @include size.select(large) {
+    @extend .body2;
+  }
 
-    &:focus {
-        outline-width: sizes.$fixed-2;
-        outline-offset: sizes.$fixed-2;
-    }
+  &:focus {
+    outline-width: sizes.$fixed-2;
+    outline-offset: sizes.$fixed-2;
+  }
 
-    &::placeholder {
-        color: var(--text-placeholder);
-    }
-    
+  &::placeholder {
+    color: var(--text-placeholder);
+  }
 }
 
 @mixin valid {
+  border-color: var(--border);
+  background-color: var(--surface1);
+
+  @include device.if-hover {
+    border-color: var(--border-hover);
+  }
+
+  &:focus {
     border-color: var(--border);
-    background-color: var(--surface1);
+  }
 
-    @include device.if-hover {
-        border-color: var(--border-hover);
+  @include device.if-touch {
+    &:active {
+      border-color: var(--border-hover);
+      background-color: var(--generic-active);
     }
+  }
 
-    &:focus {
-        border-color: var(--border);
-    }
-
-    @include device.if-touch {
-        &:active {
-            border-color: var(--border-hover);
-            background-color: var(--generic-active);
-        }
-    }
-
-    &:disabled {
-        border-color: var(--border-disabled);
-        color: var(--text-disabled);
-    }
+  &:disabled {
+    border-color: var(--border-disabled);
+    color: var(--text-disabled);
+  }
 }
 
 @mixin invalid {
-    &:invalid, &.ng-invalid.ng-touched{
-        border-color: var(--critical-border);
-        background-color: var(--critical-background-weak);
+  &:invalid,
+  &.ng-invalid.ng-touched {
+    border-color: var(--critical-border);
+    background-color: var(--critical-background-weak);
 
-        @include device.if-hover {
-            border-color: var(--critical-border-hover);
-        }
-
-        &:focus {
-            border-color: var(--critical-border);
-        }
-
-        @include device.if-touch {
-            &:active {
-                    border-color: var(--critical-border-hover);
-                    background-color: var(--critical-background-weak-hover);
-            }
-        }
+    @include device.if-hover {
+      border-color: var(--critical-border-hover);
     }
+
+    &:focus {
+      border-color: var(--critical-border);
+    }
+
+    @include device.if-touch {
+      &:active {
+        border-color: var(--critical-border-hover);
+        background-color: var(--critical-background-weak-hover);
+      }
+    }
+  }
 }

--- a/core-library/tokens/input/_input.scss
+++ b/core-library/tokens/input/_input.scss
@@ -1,49 +1,47 @@
-@use '../../util/color' as color;
-@use '../../util/theme' as theme;
-@use '../template-const' as template-const;
-@use '../sizes' as sizes;
-@use '../../util/device' as device;
-@use '../../util/size' as size;
-@use './input-const' as input-const;
+@use "../../util/color" as color;
+@use "../../util/theme" as theme;
+@use "../template-const" as template-const;
+@use "../sizes" as sizes;
+@use "../../util/device" as device;
+@use "../../util/size" as size;
+@use "./input-const" as input-const;
 
-$input-types : (
-    text,
-    password,
-    //search,
-    //file
+$input-types: (
+  text,
+  password,
+  //search,
+  //file
 );
 
-@mixin input-text-selector  {
-    @each $type in $input-types{
-        input#{template-const.$escape} {
-            @include theme.select-attribute($type, type, text) {
-                @content;
-            }
-            &:where([type="password"]){
-                // any future file type styles (duplicate for all types with seperate styles)
-                @content;
-            }
-        }
+@mixin input-text-selector {
+  @each $type in $input-types {
+    input#{template-const.$escape} {
+      @include theme.select-attribute($type, type, text) {
+        @content;
+      }
+      &:where([type="password"]) {
+        // any future file type styles (duplicate for all types with seperate styles)
+        @content;
+      }
     }
+  }
 }
 
 @mixin create {
-         @include input-text-selector() {
-                @include input-const.common();
-                @include input-const.valid();
-                @include input-const.invalid();
-                @include textPadding();
-         }
+  @include input-text-selector() {
+    @include input-const.common();
+    @include input-const.valid();
+    @include input-const.invalid();
+    @include textPadding();
+  }
 }
 
 @mixin textPadding {
+  @include size.select(small) {
+    padding: sizes.$fixed-10 sizes.$fixed-12;
+  }
 
-    @include size.selector(small) {
-        padding: sizes.$fixed-10 sizes.$fixed-12;
-    }
-
-    @include size.selector(large) {
-        padding: sizes.$fixed-14 sizes.$fixed-12;
-    }
-
+  @include size.select(large) {
+    padding: sizes.$fixed-14 sizes.$fixed-12;
+  }
 }

--- a/core-library/tokens/input/_textarea.scss
+++ b/core-library/tokens/input/_textarea.scss
@@ -1,36 +1,34 @@
-@use '../../util/color' as color;
-@use '../../util/theme' as theme;
-@use '../template-const' as template-const;
-@use '../sizes' as sizes;
-@use '../../util/device' as device;
-@use '../../util/size' as size;
-@use './input-const' as input-const;
+@use "../../util/color" as color;
+@use "../../util/theme" as theme;
+@use "../template-const" as template-const;
+@use "../sizes" as sizes;
+@use "../../util/device" as device;
+@use "../../util/size" as size;
+@use "./input-const" as input-const;
 
-@mixin input-textarea-selector  {
-    textarea#{template-const.$escape} {
-        @content;
-    }
+@mixin input-textarea-selector {
+  textarea#{template-const.$escape} {
+    @content;
+  }
 }
 
 @mixin create {
-            @include input-textarea-selector() {
-                @include input-const.common();
-                @include input-const.valid();
-                @include input-const.invalid();
-                @include layout();
-            }
+  @include input-textarea-selector() {
+    @include input-const.common();
+    @include input-const.valid();
+    @include input-const.invalid();
+    @include layout();
+  }
 }
 
 @mixin layout {
-    resize: both;
+  resize: both;
 
-    @include size.selector(small) {
-        padding: sizes.$fixed-10 sizes.$fixed-16 sizes.$fixed-10 sizes.$fixed-14;
-    }
+  @include size.select(small) {
+    padding: sizes.$fixed-10 sizes.$fixed-16 sizes.$fixed-10 sizes.$fixed-14;
+  }
 
-    @include size.selector(large) {
-        padding: sizes.$fixed-14 sizes.$fixed-16 sizes.$fixed-14 sizes.$fixed-20;
-    }
-
+  @include size.select(large) {
+    padding: sizes.$fixed-14 sizes.$fixed-16 sizes.$fixed-14 sizes.$fixed-20;
+  }
 }
-

--- a/core-library/tokens/label/_label-const.scss
+++ b/core-library/tokens/label/_label-const.scss
@@ -1,32 +1,31 @@
-@use '../../util/color' as color;
-@use '../../util/theme' as theme;
-@use '../template-const' as template-const;
-@use '../sizes' as sizes;
-@use '../../util/device' as device;
-@use '../../util/size' as size;
+@use "../../util/color" as color;
+@use "../../util/theme" as theme;
+@use "../template-const" as template-const;
+@use "../sizes" as sizes;
+@use "../../util/device" as device;
+@use "../../util/size" as size;
 
 @mixin common {
-    width: 100%;
-    border-style: solid;
-    border-width: sizes.$fixed-1;
-    border-radius: sizes.$border-radius;
-    color: var(--text-primary);
+  width: 100%;
+  border-style: solid;
+  border-width: sizes.$fixed-1;
+  border-radius: sizes.$border-radius;
+  color: var(--text-primary);
 
-    @include size.selector(small) {
-        @extend .body3;
-    }
+  @include size.select(small) {
+    @extend .body3;
+  }
 
-    @include size.selector(large) {
-        @extend .body2;
-    }
+  @include size.select(large) {
+    @extend .body2;
+  }
 
-    &:focus {
-        outline-width: sizes.$fixed-2;
-        outline-offset: sizes.$fixed-2;
-    }
+  &:focus {
+    outline-width: sizes.$fixed-2;
+    outline-offset: sizes.$fixed-2;
+  }
 
-    &::placeholder {
-        color: var(--text-placeholder);
-    }
-    
+  &::placeholder {
+    color: var(--text-placeholder);
+  }
 }

--- a/core-library/tokens/label/_label.scss
+++ b/core-library/tokens/label/_label.scss
@@ -1,29 +1,26 @@
-@use '../../util/color' as color;
-@use '../../util/theme' as theme;
-@use '../template-const' as template-const;
-@use '../sizes' as sizes;
-@use '../../util/device' as device;
-@use '../../util/size' as size;
-@use './label-const' as label-const;
-
+@use "../../util/color" as color;
+@use "../../util/theme" as theme;
+@use "../template-const" as template-const;
+@use "../sizes" as sizes;
+@use "../../util/device" as device;
+@use "../../util/size" as size;
+@use "./label-const" as label-const;
 
 @mixin create {
-         @include input-text-selector() {
-                @include label-const.common();
-                @include label-const.valid();
-                @include label-const.invalid();
-                @include textPadding();
-         }
+  @include input-text-selector() {
+    @include label-const.common();
+    @include label-const.valid();
+    @include label-const.invalid();
+    @include textPadding();
+  }
 }
 
 @mixin textPadding {
+  @include size.select(small) {
+    padding: sizes.$fixed-10 sizes.$fixed-12;
+  }
 
-    @include size.selector(small) {
-        padding: sizes.$fixed-10 sizes.$fixed-12;
-    }
-
-    @include size.selector(large) {
-        padding: sizes.$fixed-14 sizes.$fixed-12;
-    }
-
+  @include size.select(large) {
+    padding: sizes.$fixed-14 sizes.$fixed-12;
+  }
 }

--- a/core-library/tokens/radio/_radio.scss
+++ b/core-library/tokens/radio/_radio.scss
@@ -1,136 +1,132 @@
-@use '../../util/color' as color;
-@use '../../util/theme' as theme;
-@use '../../util/size' as size;
-@use '../../util/device' as device;
-@use '../template-const' as template-const;
-@use '../sizes' as token-size;
+@use "../../util/color" as color;
+@use "../../util/theme" as theme;
+@use "../../util/size" as size;
+@use "../../util/device" as device;
+@use "../template-const" as template-const;
+@use "../sizes" as token-size;
 
 @mixin selector {
-    input[type='radio']#{template-const.$escape} {
-        @content;
-    }
+  input[type="radio"]#{template-const.$escape} {
+    @content;
+  }
 }
 
 @mixin create {
-    @include selector() {
-        @include layout();
-    }
+  @include selector() {
+    @include layout();
+  }
 }
 
-@mixin small-styles(){
-    height: token-size.$relative-1-25;
-    width: token-size.$relative-1-25;
-    @include checked-circle-size(
-        token-size.$radio-selected-border-radius-small
-    );
+@mixin small-styles() {
+  height: token-size.$relative-1-25;
+  width: token-size.$relative-1-25;
+  @include checked-circle-size(token-size.$radio-selected-border-radius-small);
 }
 
-@mixin large-styles(){
-    height: token-size.$relative-1-5;
-    width: token-size.$relative-1-5;
-    @include checked-circle-size(
-        token-size.$radio-selected-border-radius-large
-    );
+@mixin large-styles() {
+  height: token-size.$relative-1-5;
+  width: token-size.$relative-1-5;
+  @include checked-circle-size(token-size.$radio-selected-border-radius-large);
 }
-
 
 @mixin layout {
-    border-radius: token-size.$border-radius-circle;
-    appearance: none;
-    margin: token-size.$form-control-margin;
-    aspect-ratio: 1 / 1;
-    box-sizing: border-box;
-    box-shadow: token-size.$border-style;
-    vertical-align: top;
-    cursor: pointer;
+  border-radius: token-size.$border-radius-circle;
+  appearance: none;
+  margin: token-size.$form-control-margin;
+  aspect-ratio: 1 / 1;
+  box-sizing: border-box;
+  box-shadow: token-size.$border-style;
+  vertical-align: top;
+  cursor: pointer;
 
-    @include size.selector(small) {
-        @include small-styles();
-        &.large {
-            @include large-styles();
-        }
+  @include size.select(small) {
+    @include small-styles();
+    &.large {
+      @include large-styles();
     }
+  }
 
-    @include size.selector(large) {
-        @include large-styles();
-        &.small {
-            @include small-styles();
-        }
+  @include size.select(large) {
+    @include large-styles();
+    &.small {
+      @include small-styles();
     }
+  }
 
-    @include device.if-hover {
-            color: var(--formcontrol-hover);
+  @include device.if-hover {
+    color: var(--formcontrol-hover);
+  }
+
+  &:disabled {
+    --border: var(--border-disabled);
+    cursor: not-allowed;
+    & + label {
+      color: var(--text-disabled);
     }
+  }
 
-    &:disabled {
-        --border: var(--border-disabled);
-        cursor: not-allowed;
-        & + label {
-            color: var(--text-disabled);
-        }
+  &:enabled {
+    &:active {
+      background-color: var(--generic-active);
     }
+  }
 
-    &:enabled {
-        &:active {
-            background-color: var(--generic-active);
-        }
-    }
-
-    @include checked();
-    @include invalid();
+  @include checked();
+  @include invalid();
 }
 
 @mixin checked {
-    &:checked {
-        --border: var(--formcontrol);
+  &:checked {
+    --border: var(--formcontrol);
 
-        &:disabled {
-            --border: var(--formcontrol-disabled);
-        }
-
-        &:enabled {
-            @include device.if-hover {
-                --border: var(--formcontrol-hover);
-            }
-
-            &:active {
-                --border: var(--formcontrol-hover);
-            }
-        }
+    &:disabled {
+      --border: var(--formcontrol-disabled);
     }
+
+    &:enabled {
+      @include device.if-hover {
+        --border: var(--formcontrol-hover);
+      }
+
+      &:active {
+        --border: var(--formcontrol-hover);
+      }
+    }
+  }
 }
 
-@mixin invalid {  
-    &:invalid:not(:disabled), &.ng-invalid.ng-touched:not(:disabled){
-        --border: var(--critical-background);
-        background-color: var(--critical-background-weak);
+@mixin invalid {
+  &:invalid:not(:disabled),
+  &.ng-invalid.ng-touched:not(:disabled) {
+    --border: var(--critical-background);
+    background-color: var(--critical-background-weak);
 
-        @include device.if-hover {
-            --border: var(--critical-border-hover);
-            background-color: var(--critical-background-weak-hover);
-        }
-
-        &:active {
-            --border: var(--critical-border-hover);
-            background-color: var(--critical-background-weak-active);
-        }
-
-        &:checked {
-            background-color: var(--surface1);
-
-            @include device.if-hover {
-                --border: var(--critical-background-hover);
-            }
-
-            &:active {
-                --border: var(--critical-background-active);
-            }
-        }
+    @include device.if-hover {
+      --border: var(--critical-border-hover);
+      background-color: var(--critical-background-weak-hover);
     }
+
+    &:active {
+      --border: var(--critical-border-hover);
+      background-color: var(--critical-background-weak-active);
+    }
+
+    &:checked {
+      background-color: var(--surface1);
+
+      @include device.if-hover {
+        --border: var(--critical-background-hover);
+      }
+
+      &:active {
+        --border: var(--critical-background-active);
+      }
+    }
+  }
 }
 
 @mixin checked-circle-size($border-size) {
-    &:checked {
-        box-shadow: $border-size;
-    }
+  &:checked {
+    box-shadow: $border-size;
+  }
 }

--- a/core-library/typography/_typography.scss
+++ b/core-library/typography/_typography.scss
@@ -1,137 +1,136 @@
-@use 'fonts';
-@use '../tokens/text' as text;
-@use '../util/size' as size;
-@use '../util/color' as color;
-@use '../tokens/template-const' as template-const;
-@forward 'fonts' as fonts-*;
-@use 'sass:map';
+@use "fonts";
+@use "../tokens/text" as text;
+@use "../util/size" as size;
+@use "../util/color" as color;
+@use "../tokens/template-const" as template-const;
+@forward "fonts" as fonts-*;
+@use "sass:map";
 
 /// references sass variables to create font level specific properties
 /// @param {Map} $map - the map of fonts to reference
 /// @param {Number} $level - the font level to reference
 @mixin fontSize($map, $level) {
-    font-size: map.get($map, $level, font-size);
-    line-height: map.get($map, $level, line-height);
+  font-size: map.get($map, $level, font-size);
+  line-height: map.get($map, $level, line-height);
 }
 
 @mixin fontSet($type, $level, $weight) {
-    @if $type == heading {
-        @include fontSize(map.get(text.$heading, level), $level);
-        font-family: map.get(text.$heading, family);
-        font-weight: map.get(text.$heading, weight, $weight);
-    } @else if $type == body {
-        @include fontSize(map.get(text.$body, level), $level);
-        font-family: map.get(text.$body, family);
-        font-weight: map.get(text.$body, weight, $weight);
-    }
+  @if $type == heading {
+    @include fontSize(map.get(text.$heading, level), $level);
+    font-family: map.get(text.$heading, family);
+    font-weight: map.get(text.$heading, weight, $weight);
+  } @else if $type == body {
+    @include fontSize(map.get(text.$body, level), $level);
+    font-family: map.get(text.$body, family);
+    font-weight: map.get(text.$body, weight, $weight);
+  }
 }
 
 /// Defines font weight for emphasis elements
 /// @param {Number} $weight font-weight to use for emphasis on parent
 @mixin emphasis($weight) {
-    & strong,
-    & .emphasis,
-    & b,
-    & .bold {
-        font-weight: $weight;
-    }
+  & strong,
+  & .emphasis,
+  & b,
+  & .bold {
+    font-weight: $weight;
+  }
 }
 
 /// Defines heading levels
 @mixin headings {
-    %heading {
-        color: var(--text);
-        font-weight: map.get(text.$heading, weight, regular);
-        font-family: map.get(text.$heading, family);
-        @include emphasis(map.get(text.$heading, weight, emphasis));
+  %heading {
+    color: var(--text);
+    font-weight: map.get(text.$heading, weight, regular);
+    font-family: map.get(text.$heading, family);
+    @include emphasis(map.get(text.$heading, weight, emphasis));
+  }
+
+  #{template-const.$root-selectors} {
+    h1,
+    .h1 {
+      @extend %heading;
+      @include fontSize(map.get(text.$heading, level), 1);
     }
 
-    #{template-const.$root-selectors} {
-        h1,
-        .h1 {
-            @extend %heading;
-            @include fontSize(map.get(text.$heading, level), 1);
-        }
-
-        h2,
-        .h2 {
-            @extend %heading;
-            @include fontSize(map.get(text.$heading, level), 2);
-        }
-
-        h3,
-        .h3 {
-            @extend %heading;
-            @include fontSize(map.get(text.$heading, level), 3);
-        }
-
-        h4,
-        .h4 {
-            @extend %heading;
-            @include fontSize(map.get(text.$heading, level), 4);
-        }
-
-        h5,
-        .h5 {
-            @extend %heading;
-            @include fontSize(map.get(text.$heading, level), 5);
-        }
-
-        h6,
-        .h6 {
-            @extend %heading;
-            @include fontSize(map.get(text.$heading, level), 6);
-        }
+    h2,
+    .h2 {
+      @extend %heading;
+      @include fontSize(map.get(text.$heading, level), 2);
     }
+
+    h3,
+    .h3 {
+      @extend %heading;
+      @include fontSize(map.get(text.$heading, level), 3);
+    }
+
+    h4,
+    .h4 {
+      @extend %heading;
+      @include fontSize(map.get(text.$heading, level), 4);
+    }
+
+    h5,
+    .h5 {
+      @extend %heading;
+      @include fontSize(map.get(text.$heading, level), 5);
+    }
+
+    h6,
+    .h6 {
+      @extend %heading;
+      @include fontSize(map.get(text.$heading, level), 6);
+    }
+  }
 }
 
 /// Defines body levels
 @mixin body {
-    %body {
-        color: var(--text);
-        font-weight: map.get(text.$body, weight, regular);
-        font-family: map.get(text.$body, family);
-        @include emphasis(map.get(text.$body, weight, emphasis));
+  %body {
+    color: var(--text);
+    font-weight: map.get(text.$body, weight, regular);
+    font-family: map.get(text.$body, family);
+    @include emphasis(map.get(text.$body, weight, emphasis));
+  }
+
+  #{template-const.$root-selectors} {
+    .body1 {
+      @extend %body;
+      @include fontSize(map.get(text.$body, level), 1);
     }
 
-    #{template-const.$root-selectors} {
-        .body1 {
-            @extend %body;
-            @include fontSize(map.get(text.$body, level), 1);
-        }
-
-        .body2 {
-            @extend %body;
-            @include fontSize(map.get(text.$body, level), 2);
-        }
-
-        .body3 {
-            @extend %body;
-            @include fontSize(map.get(text.$body, level), 3);
-        }
-
-        .body4 {
-            @extend %body;
-            @include fontSize(map.get(text.$body, level), 4);
-        }
-
-        @include size.selector(small) {
-            body {
-                @extend .body3;
-            }
-        }
-
-        @include size.selector(large) {
-            body {
-                @extend .body2;
-            }
-        }
+    .body2 {
+      @extend %body;
+      @include fontSize(map.get(text.$body, level), 2);
     }
+
+    .body3 {
+      @extend %body;
+      @include fontSize(map.get(text.$body, level), 3);
+    }
+
+    .body4 {
+      @extend %body;
+      @include fontSize(map.get(text.$body, level), 4);
+    }
+
+    @include size.select(small) {
+      body {
+        @extend .body3;
+      }
+    }
+
+    @include size.select(large) {
+      body {
+        @extend .body2;
+      }
+    }
+  }
 }
-
 
 /// Defines typography used in the design system
 @mixin create() {
-    @include body();
-    @include headings();
+  @include body();
+  @include headings();
 }

--- a/core-library/util/_size.scss
+++ b/core-library/util/_size.scss
@@ -14,7 +14,7 @@ $sizes: (small, large);
 
 /// Content included within this mixin will only be included if the size aligns to the value passed
 /// @param {String} $value key from $sizes list, when size aligns to $value, content will display
-@mixin selector($value: small) {
+@mixin select($value: small) {
   @include theme.select-attribute(
     $value: $value,
     $attribute: size,


### PR DESCRIPTION
PR Approval Template
Why are these changes introduced?

Related story #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/903659))
QA LINK: N/A (minor changes with no need for QA)

What is this pull request doing?

Fixes a global project issue with the 'selector' utility mixin which interacts poorly with the mandatory 'selector' mixin in each stylesheet:
  - renames 'selector' utility mixin to 'select'
  - find a replace for all size.selector to update them per new utility mixin name
  - search for all 'selectors' hotfix mixins in stylesheets to bring back the uniform 'selector' mixin name 

Reviewer checklist:
Specifically for this PR:

- [ ] Check if 'selector' utility mixin is being replaced by 'select' utility mixin. (i.e. size.selector is now size.select)

- [ ] Check if 'selectors' mixins are being changed to 'selector' mixins.