### PR TITLE
Qa/request form bug fix

### DIFF
--- a/component-library/src/app/pages/request-form/request-form.component.scss
+++ b/component-library/src/app/pages/request-form/request-form.component.scss
@@ -1,4 +1,5 @@
 @use "../../../../../core-library/util/device" as device;
+@use '~@ircc-ca/ds-sdc-core/typography/typography';
 
 .content-doc-wrapper {
   box-sizing: border-box;
@@ -23,6 +24,7 @@ h3 {
 .body1.intro {
   margin-top: 0px;
   margin-bottom: 24px;
+  @include typography.fontSet(body, 1, regular);
 }
 
 .body3.subtext-1 {

--- a/component-library/src/app/pages/request-form/request-form.component.ts
+++ b/component-library/src/app/pages/request-form/request-form.component.ts
@@ -91,7 +91,7 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
         errorLOV: 'RequestForm.requiredRadioError'
       }
     ],
-    size: 'large',
+    size: 'small',
     disabled: false,
     error: true
   };
@@ -117,7 +117,7 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
         errorLOV: 'RequestForm.requiredRadioError'
       }
     ],
-    size: 'large',
+    size: 'small',
     disabled: false,
     error: true
   };
@@ -130,7 +130,7 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
     required: true,
     charLimit: '50',
     resizable: 'vertical',
-    size: 'large',
+    size: 'small',
     errorMessages: [
       {
         key: 'required',
@@ -151,7 +151,7 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
     desc: 'RequestForm.requestDetailsDesc',
     required: true,
     resizable: 'vertical',
-    size: 'large',
+    size: 'small',
     errorMessages: [
       {
         key: 'required',
@@ -172,7 +172,7 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
     desc: 'RequestForm.useCaseDesc',
     required: true,
     resizable: 'vertical',
-    size: 'large',
+    size: 'small',
     errorMessages: [
       {
         key: 'required',
@@ -193,7 +193,7 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
     desc: 'RequestForm.referencesCaseDesc',
     hint: 'RequestForm.referencesHint',
     resizable: 'vertical',
-    size: 'large'
+    size: 'small'
     // errorMessages?: IErrorPairs[];
     // errorIcon?: IErrorIconConfig;
   };
@@ -204,7 +204,7 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
     label: 'RequestForm.urgentDetailsLabel',
     required: true,
     resizable: 'vertical',
-    size: 'large',
+    size: 'small',
     errorMessages: [
       {
         key: 'required',
@@ -233,7 +233,7 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
     label: 'RequestForm.requestedDateLabel',
     desc: 'RequestForm.requestedDateDesc',
     required: true,
-    size: 'large',
+    size: 'small',
     errorMessages: this.datePickerErrorMessages,
     minYear: 2023
   };
@@ -249,7 +249,7 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
     private translate: TranslateService,
     private lang: LangSwitchService,
     private requestFormService: RequestFormService
-  ) {}
+  ) { }
   ngAfterViewInit(): void {
     /**
      * Set local storage form data when form values change after init so we're not setting and getting at the same time

--- a/component-library/src/app/pages/request-form/request-form.component.ts
+++ b/component-library/src/app/pages/request-form/request-form.component.ts
@@ -249,7 +249,7 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
     private translate: TranslateService,
     private lang: LangSwitchService,
     private requestFormService: RequestFormService
-  ) { }
+  ) {}
   ngAfterViewInit(): void {
     /**
      * Set local storage form data when form values change after init so we're not setting and getting at the same time


### PR DESCRIPTION
**PR Approval Template**
**Why are these changes introduced?**


**What is this pull request doing?**
* This PR fixes the font-set in the form and has passed QA review

**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)

** File names and hierarchies are in keeping with our norms:
* Interfaces start with 'I' followed by a capital letter and camel case (IInterfaceExample) and are descriptive
* Subjects are suffixed with 'Subj' (ex: thisIsAnExampleSubj)
* Subscriptions are suffixed with 'Sub' (ex: thisIsAnExampleSub)
* Observables ere suffixed with 'Obs$' (ex: thisIsAnExampleObs$)
* Class and variable names are camel case
* Class names should start with a capital letter (i.e. ExampleClass)
* Variable names should start with a lower case letter (i.e thisIsAnExampleVariable)
* All caps and underscores are used for exported constants (THIS_IS_A_CONSTANT)
* Names are all spelled correctly
* ngOnInit and constructor is removed when not used
* ':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?

**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.