### PR TITLE
Bug: ds-icon-container-must-be-unique

### DIFF
--- a/component-library/component-lib/src/lib/shared/icon/icon.component.html
+++ b/component-library/component-lib/src/lib/shared/icon/icon.component.html
@@ -1,4 +1,4 @@
-<span id="ds-icon-container">
+<span class="ds-icon-container">
   <span
     #iconSpan
     [attr.aria-hidden]="config.ariaLabel ? false : true"

--- a/core-library/component-styling/icon-button/_icon-button.scss
+++ b/core-library/component-styling/icon-button/_icon-button.scss
@@ -74,7 +74,7 @@
       justify-content: center;
     }
 
-    #ds-icon-container {
+    .ds-icon-container {
       > span {
         display: flex;
       }
@@ -105,7 +105,6 @@
       }
     }
 
-
     @include size.select(large) {
       @include lg;
     }
@@ -122,3 +121,4 @@
     }
   }
 }
+

--- a/core-library/component-styling/spinner/_spinner.scss
+++ b/core-library/component-styling/spinner/_spinner.scss
@@ -52,7 +52,7 @@ $selectors: "ircc-cl-lib-spinner";
       border-radius: 50%;
       .spinner-icon {
         align-self: center;
-        > #ds-icon-container > span > svg {
+        > .ds-icon-container > span > svg {
           width: 40px;
           height: 40px;
         }
@@ -83,7 +83,7 @@ $selectors: "ircc-cl-lib-spinner";
       height: 28px;
       border-radius: 50%;
       .spinner-icon {
-        > #ds-icon-container > span > svg {
+        > .ds-icon-container > span > svg {
           width: 14px;
           height: 16px;
         }
@@ -182,7 +182,7 @@ $selectors: "ircc-cl-lib-spinner";
         border-radius: 50%;
         .spinner-icon {
           align-self: flex-end;
-          > #ds-icon-container > span > svg {
+          > .ds-icon-container > span > svg {
             width: 12px;
             height: 12px;
           }


### PR DESCRIPTION
Why are these changes introduced?

Related story [914167](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/914167/)
[QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-button-id-of-ds-icon-container-must-be-unique/en/overview)
What is this pull request doing?

Replacing the #ds-icon-container selector with .ds-icon-container

Reviewer checklist:

Pass the pages through a WCAG tool to make sure we no longer have the ds-icon-container duplicate ID error.