### PR TITLE
Removed invalid from component tokens

### DIFF
--- a/core-library/component-styling/select/_select-component.scss
+++ b/core-library/component-styling/select/_select-component.scss
@@ -136,7 +136,6 @@ $selectors: "ircc-cl-lib-select";
     }
   }
 
-  select:invalid,
   select.ng-invalid.ng-touched {
     border-color: var(--critical-border);
     background-color: var(--critical-background-weak);

--- a/core-library/tokens/checkbox/_checkbox.scss
+++ b/core-library/tokens/checkbox/_checkbox.scss
@@ -96,7 +96,6 @@
 }
 
 @mixin invalid {
-  &:invalid,
   &.ng-invalid.ng-touched,
   &.error {
     --border: var(--critical-border);

--- a/core-library/tokens/input/_input-const.scss
+++ b/core-library/tokens/input/_input-const.scss
@@ -56,7 +56,6 @@
 }
 
 @mixin invalid {
-  &:invalid,
   &.ng-invalid.ng-touched {
     border-color: var(--critical-border);
     background-color: var(--critical-background-weak);

--- a/core-library/tokens/radio/_radio.scss
+++ b/core-library/tokens/radio/_radio.scss
@@ -96,7 +96,6 @@
 }
 
 @mixin invalid {
-  &:invalid:not(:disabled),
   &.ng-invalid.ng-touched:not(:disabled) {
     --border: var(--critical-background);
     background-color: var(--critical-background-weak);


### PR DESCRIPTION
- Removed invalid from component tokens

**Explanation:**
Having `invalid` and `.ng-invalid.ng-touched` at the same time will remain the select in error state all the time, no matter what you do