### PR TITLE
Bug/basic input

### DIFF
--- a/component-library/component-lib/src/lib/form-components/input/input.component.ts
+++ b/component-library/component-lib/src/lib/form-components/input/input.component.ts
@@ -84,7 +84,7 @@ export class InputComponent implements ControlValueAccessor, OnInit, OnChanges {
   /**
    * Type refers to the 2 different input options: basic text or password as the password type has additional configuration
    */
-  @Input() type: keyof typeof InputTypes = InputTypes.password;
+  @Input() type: keyof typeof InputTypes = InputTypes.text;
 
   @Input() size?: keyof typeof DSSizes;
   @Input() label?: string;
@@ -114,7 +114,34 @@ export class InputComponent implements ControlValueAccessor, OnInit, OnChanges {
   constructor(
     public standAloneFunctions: StandAloneFunctions,
     private translate: TranslateService
-  ) {}
+  ) {
+    //set config from individual options, if present
+    if (this.formGroup !== this.formGroupEmpty) {
+      this.config.formGroup = this.formGroup;
+    }
+    if (this.id !== '') {
+      this.config.id = this.id;
+    }
+    if (this.size) this.config.size = this.size;
+    if (this.label) this.config.label = this.label;
+    if (this.hint) this.config.hint = this.hint;
+    if (this.desc) this.config.desc = this.desc;
+    if (this.required) this.config.required = this.required;
+    if (this.placeholder) this.config.placeholder = this.placeholder;
+    if (this.errorMessages) this.config.errorMessages = this.errorMessages;
+    if (this.type) this.config.type = this.type;
+
+    if (!this.config.type) {
+      this.config.type = InputTypes.text;
+    } else if (this.config.type === InputTypes.password) {
+      this.showPassword = false;
+      this.typeControl = InputTypes.password;
+    }
+
+    this.type === InputTypes.text
+      ? (this.showPassword = false)
+      : (this.showPassword = true);
+  }
 
   //Removed '!' and added null case in onChange
   private onTouch?: () => void;
@@ -144,33 +171,6 @@ export class InputComponent implements ControlValueAccessor, OnInit, OnChanges {
       this.config.required,
       this.config.labelIconConfig
     );
-    
-    //set config from individual options, if present
-    if (this.formGroup !== this.formGroupEmpty) {
-      this.config.formGroup = this.formGroup;
-    }
-    if (this.id !== '') {
-      this.config.id = this.id;
-    }
-    if (this.size) this.config.size = this.size;
-    if (this.label) this.config.label = this.label;
-    if (this.hint) this.config.hint = this.hint;
-    if (this.desc) this.config.desc = this.desc;
-    if (this.required) this.config.required = this.required;
-    if (this.placeholder) this.config.placeholder = this.placeholder;
-    if (this.errorMessages) this.config.errorMessages = this.errorMessages;
-    if (this.type) this.config.type = this.type;
-
-    if (!this.config.type) {
-      this.config.type = InputTypes.text;
-    } else if (this.config.type === InputTypes.password) {
-      this.showPassword = false;
-      this.typeControl = InputTypes.password;
-    }
-
-    this.type === InputTypes.text
-      ? (this.showPassword = false)
-      : (this.showPassword = true);
 
     //set disable to true when form is disabled
     this.config.formGroup.valueChanges.subscribe((change) => {

--- a/component-library/component-lib/src/lib/form-components/input/input.component.ts
+++ b/component-library/component-lib/src/lib/form-components/input/input.component.ts
@@ -84,7 +84,7 @@ export class InputComponent implements ControlValueAccessor, OnInit, OnChanges {
   /**
    * Type refers to the 2 different input options: basic text or password as the password type has additional configuration
    */
-  @Input() type: keyof typeof InputTypes = InputTypes.text;
+  @Input() type: keyof typeof InputTypes = InputTypes.password;
 
   @Input() size?: keyof typeof DSSizes;
   @Input() label?: string;
@@ -122,14 +122,6 @@ export class InputComponent implements ControlValueAccessor, OnInit, OnChanges {
     if (this.id !== '') {
       this.config.id = this.id;
     }
-    if (this.size) this.config.size = this.size;
-    if (this.label) this.config.label = this.label;
-    if (this.hint) this.config.hint = this.hint;
-    if (this.desc) this.config.desc = this.desc;
-    if (this.required) this.config.required = this.required;
-    if (this.placeholder) this.config.placeholder = this.placeholder;
-    if (this.errorMessages) this.config.errorMessages = this.errorMessages;
-    if (this.type) this.config.type = this.type;
 
     if (!this.config.type) {
       this.config.type = InputTypes.text;
@@ -137,6 +129,15 @@ export class InputComponent implements ControlValueAccessor, OnInit, OnChanges {
       this.showPassword = false;
       this.typeControl = InputTypes.password;
     }
+
+    if (this.size) this.config.size = this.size;
+    if (this.label) this.config.label = this.label;
+    if (this.hint) this.config.hint = this.hint;
+    if (this.desc) this.config.desc = this.desc;
+    if (this.required) this.config.required = this.required;
+    if (this.placeholder) this.config.placeholder = this.placeholder;
+    if (this.errorMessages) this.config.errorMessages = this.errorMessages;
+    // if (this.type) this.config.type = this.type;
 
     this.type === InputTypes.text
       ? (this.showPassword = false)

--- a/component-library/component-lib/src/lib/form-components/input/input.component.ts
+++ b/component-library/component-lib/src/lib/form-components/input/input.component.ts
@@ -137,9 +137,6 @@ export class InputComponent implements ControlValueAccessor, OnInit, OnChanges {
     if (this.required) this.config.required = this.required;
     if (this.placeholder) this.config.placeholder = this.placeholder;
     if (this.errorMessages) this.config.errorMessages = this.errorMessages;
-    // if (this.type) this.config.type = this.type;
-
-
   }
 
   //Removed '!' and added null case in onChange

--- a/component-library/component-lib/src/lib/form-components/input/input.component.ts
+++ b/component-library/component-lib/src/lib/form-components/input/input.component.ts
@@ -139,9 +139,7 @@ export class InputComponent implements ControlValueAccessor, OnInit, OnChanges {
     if (this.errorMessages) this.config.errorMessages = this.errorMessages;
     // if (this.type) this.config.type = this.type;
 
-    this.type === InputTypes.text
-      ? (this.showPassword = false)
-      : (this.showPassword = true);
+
   }
 
   //Removed '!' and added null case in onChange
@@ -161,6 +159,10 @@ export class InputComponent implements ControlValueAccessor, OnInit, OnChanges {
     this.translate.onLangChange.subscribe((change) => {
       this.setLang(change.lang);
     });
+    
+    this.type === InputTypes.text
+    ? (this.showPassword = false)
+    : (this.showPassword = true);
 
     this.labelConfig = this.standAloneFunctions.makeLabelConfig(
       this.config.formGroup,

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.scss
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.scss
@@ -2,4 +2,5 @@
   max-width: 320px;
   padding-top: 54px;
   padding-bottom: 54px;
+  width: 232px;
 }

--- a/component-library/src/app/pages/input-documentation/input-documentation.component.html
+++ b/component-library/src/app/pages/input-documentation/input-documentation.component.html
@@ -30,7 +30,7 @@
     </h5>
     <app-component-preview
       class="h6 component-preview"
-      copyText="<ircc-cl-lib-input type='text'></ircc-cl-lib-input>"
+      copyText="<ircc-cl-lib-input type='password'></ircc-cl-lib-input>"
       componentType="input"
     >
       <ircc-cl-lib-input [config]="passwordInputConfig"></ircc-cl-lib-input>

--- a/component-library/src/app/pages/input-documentation/input-documentation.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-documentation.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { IInputComponentConfig, InputTypes } from 'ircc-ds-angular-component-library';
+import {
+  IInputComponentConfig,
+  InputTypes
+} from 'ircc-ds-angular-component-library';
 
 import {
   slugAnchorType,

--- a/component-library/src/app/pages/input-documentation/input-documentation.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-documentation.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { IInputComponentConfig } from 'ircc-ds-angular-component-library';
+import { IInputComponentConfig, InputTypes } from 'ircc-ds-angular-component-library';
 
 import {
   slugAnchorType,
@@ -33,14 +33,14 @@ export class InputDocumentationComponent implements OnInit {
     id: this.BASIC_INPUT_ID,
     formGroup: this.form_input,
     label: 'General.Label',
-    type: 'text'
+    type: InputTypes.text
   };
 
   passwordInputConfig: IInputComponentConfig = {
     id: this.PASSWORD_INPUT_ID,
     formGroup: this.form_input,
     label: 'Input.LabelText2',
-    type: 'password'
+    type: InputTypes.password
   };
 
   inputTitleSlugConfig: slugTitleURLConfig = {


### PR DESCRIPTION
**PR Approval Template**
**Why are these changes introduced?**
* Related story #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/919826))

**What is this pull request doing?**
* Small fix to initialize the component default values in the constructor rather than OnInit
* Set @Input default initial value to text
* Small template fix for the copyStyle to show correct type of 'password'
* Use exported enum Types instead of hard coded strings

**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)

** File names and hierarchies are in keeping with our norms:
* Interfaces start with 'I' followed by a capital letter and camel case (IInterfaceExample) and are descriptive
* Subjects are suffixed with 'Subj' (ex: thisIsAnExampleSubj)
* Subscriptions are suffixed with 'Sub' (ex: thisIsAnExampleSub)
* Observables ere suffixed with 'Obs$' (ex: thisIsAnExampleObs$)
* Class and variable names are camel case
* Class names should start with a capital letter (i.e. ExampleClass)
* Variable names should start with a lower case letter (i.e thisIsAnExampleVariable)
* All caps and underscores are used for exported constants (THIS_IS_A_CONSTANT)
* Names are all spelled correctly
* ngOnInit and constructor is removed when not used
* ':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?

**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.