### PR TITLE
Indicator: Text size should not be wider than 200px at any given time.

### DIFF
--- a/component-library/component-lib/src/lib/shared/indicator/indicator.component.ts
+++ b/component-library/component-lib/src/lib/shared/indicator/indicator.component.ts
@@ -80,8 +80,8 @@ export class IndicatorComponent implements OnInit, AfterViewInit, OnChanges {
   @Input() palette?: keyof typeof IndicatorPalette; // Colour
   @Input() ariaLabel?: string; // Aria label line of value
   @Input() tabIndex = undefined;
-  
-  @ViewChild('label') label?: ElementRef<HTMLDivElement>;
+
+  @ViewChild('label', { static: false }) label?: ElementRef<HTMLDivElement>;
   EIndicatorStatus = IndicatorStatus;
   rounded?: boolean;
   abbr?: boolean; // Display abbr tag when text is truncated
@@ -97,7 +97,6 @@ export class IndicatorComponent implements OnInit, AfterViewInit, OnChanges {
     if (this.palette) this.config.palette = this.palette;
     if (this.ariaLabel) this.config.ariaLabel = this.ariaLabel;
 
-
     this.checkLabelRounded();
     this.checkNumber();
 
@@ -107,13 +106,14 @@ export class IndicatorComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   ngAfterViewInit() {
-    this.checkLabelLength();
+    setTimeout(() => this.checkLabelLength());
   }
 
   ngOnChanges(changes: SimpleChanges) {
     this.checkNumber();
     this.checkLabelRounded();
     this.checkLabelLength();
+    setTimeout(() => this.checkLabelLength());
   }
 
   // Check if number exceeds 99
@@ -136,6 +136,7 @@ export class IndicatorComponent implements OnInit, AfterViewInit, OnChanges {
 
   // Check if div exceeds 200px
   private checkLabelLength() {
+    if (this.config.type !== 'text') return;
     // Max 200px - padding 8px x2
     this.abbr = <boolean>(
       (this.label?.nativeElement?.offsetWidth &&


### PR DESCRIPTION
Why are these changes introduced?
- Related story [907976](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/907976)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-indicate_pst_event/en/michael-en)

What is this pull request doing?

- Fix length detection when pasting a long string for indicator

Reviewer checklist:

1. Go to https://d1whfh0luwluq8.cloudfront.net/qa-indicate_pst_event/en/michael-en page and click on "Indicator Component".
2. Select the type as "Text", and Add the Label as "Immigration Refugee Citizenship of Canada"
3. You should notice the Indicator is showing truncated size. 