### PR TITLE
Button: standardize icon size

### DIFF
--- a/component-library/component-lib/src/lib/shared/button/button.component.html
+++ b/component-library/component-lib/src/lib/shared/button/button.component.html
@@ -17,6 +17,7 @@
     >
       <ircc-cl-lib-icon
         [config]="{ FA_keywords: config.icon }"
+        [size]="config.size"
       ></ircc-cl-lib-icon>
     </span>
     <span class="text"><ng-content></ng-content></span>

--- a/component-library/component-lib/src/lib/shared/button/button.component.ts
+++ b/component-library/component-lib/src/lib/shared/button/button.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { DSSizes } from '../../../shared/constants/jl-components.constants';
 
 export enum ButtonCategories {
   primary = 'primary',
@@ -30,7 +31,7 @@ export enum ButtonIconDirection {
 export interface IButtonConfig {
   id: string;
   category?: keyof typeof ButtonCategories;
-  size?: keyof typeof ButtonSize;
+  size?: keyof typeof DSSizes;
   color?: keyof typeof ButtonColor;
   ariaLabel?: string;
   disabled?: boolean;
@@ -49,7 +50,7 @@ export class ButtonComponent {
   };
   @Input() id = '';
   @Input() category?: keyof typeof ButtonCategories;
-  @Input() size?: keyof typeof ButtonSize;
+  @Input() size?: keyof typeof DSSizes;
   @Input() color?: keyof typeof ButtonColor;
   @Input() ariaLabel?: string;
   @Input() disabled?: boolean;

--- a/component-library/component-lib/src/lib/shared/icon/icon.component.ts
+++ b/component-library/component-lib/src/lib/shared/icon/icon.component.ts
@@ -37,6 +37,9 @@ export class IconComponent implements OnChanges, OnInit {
       spanContent += `></i>`;
       this.iconSpan.nativeElement.innerHTML = spanContent;
     }
+
+    if (changes['size'] && !changes['size'].firstChange)
+      this.config.size = this.size;
   }
 
   ngOnInit() {

--- a/core-library/component-styling/icon/_icon.scss
+++ b/core-library/component-styling/icon/_icon.scss
@@ -16,15 +16,15 @@
 
 @mixin large-styles() {
   svg {
-    height: 20px;
-    width: 20px;
+    height: 24px;
+    width: 24px;
   }
 }
 
 @mixin small-styles() {
   svg {
-    height: 16px;
-    width: 16px;
+    height: 20px;
+    width: 20px;
   }
 }
 


### PR DESCRIPTION
Why are these changes introduced?

- Related story [922323](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/922323)

- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-button_icon_size/en/buttons)

What is this pull request doing?

- Replace `ButtonSize` enum with `DSSizes`
- Correct button icon size to 20x20 (small) & 24x24 (large)

Reviewer checklist:

- Scroll to button demo
- Change Icon to Leading or Trailing
- Check icon size