### PR TITLE
Bug/side nav anchor

### DIFF
--- a/component-library/component-lib/src/lib/header-footer/language-switch/language-switch.component.ts
+++ b/component-library/component-lib/src/lib/header-footer/language-switch/language-switch.component.ts
@@ -44,7 +44,7 @@ export class LanguageSwitchComponent implements OnInit {
   @HostListener('window:resize', ['$event'])
   handleResize(e: any) {
     if (isPlatformBrowser(this.platformId)) {
-      this.isMobile = window.innerWidth <= 360; //tablet breakpoint
+      this.isMobile = window.innerWidth <= 768; //tablet breakpoint
       this.setText(this.translate.currentLang);
     }
   }

--- a/component-library/component-lib/src/lib/shared/button/button.component.html
+++ b/component-library/component-lib/src/lib/shared/button/button.component.html
@@ -17,6 +17,7 @@
     >
       <ircc-cl-lib-icon
         [config]="{ FA_keywords: config.icon }"
+        [size]="config.size"
       ></ircc-cl-lib-icon>
     </span>
     <span class="text"><ng-content></ng-content></span>

--- a/component-library/component-lib/src/lib/shared/button/button.component.ts
+++ b/component-library/component-lib/src/lib/shared/button/button.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { DSSizes } from '../../../shared/constants/jl-components.constants';
 
 export enum ButtonCategories {
   primary = 'primary',
@@ -30,7 +31,7 @@ export enum ButtonIconDirection {
 export interface IButtonConfig {
   id: string;
   category?: keyof typeof ButtonCategories;
-  size?: keyof typeof ButtonSize;
+  size?: keyof typeof DSSizes;
   color?: keyof typeof ButtonColor;
   ariaLabel?: string;
   disabled?: boolean;
@@ -49,7 +50,7 @@ export class ButtonComponent {
   };
   @Input() id = '';
   @Input() category?: keyof typeof ButtonCategories;
-  @Input() size?: keyof typeof ButtonSize;
+  @Input() size?: keyof typeof DSSizes;
   @Input() color?: keyof typeof ButtonColor;
   @Input() ariaLabel?: string;
   @Input() disabled?: boolean;

--- a/component-library/component-lib/src/lib/shared/icon/icon.component.ts
+++ b/component-library/component-lib/src/lib/shared/icon/icon.component.ts
@@ -37,6 +37,9 @@ export class IconComponent implements OnChanges, OnInit {
       spanContent += `></i>`;
       this.iconSpan.nativeElement.innerHTML = spanContent;
     }
+
+    if (changes['size'] && !changes['size'].firstChange)
+      this.config.size = this.size;
   }
 
   ngOnInit() {

--- a/component-library/component-lib/src/lib/shared/navigation/nav-item-nav/nav-item-nav.component.html
+++ b/component-library/component-lib/src/lib/shared/navigation/nav-item-nav/nav-item-nav.component.html
@@ -11,6 +11,7 @@
         [routerLink]="config?.href || '' | translate"
         [fragment]="config?.anchor"
         [routerLinkActive]="'active-link'"
+        [routerLinkActiveOptions]="fragMatchOptions"
         (click)="linkClick($event)"
         #internalLink
       >

--- a/component-library/component-lib/src/lib/shared/navigation/nav-item-nav/nav-item-nav.component.ts
+++ b/component-library/component-lib/src/lib/shared/navigation/nav-item-nav/nav-item-nav.component.ts
@@ -6,6 +6,7 @@ import {
   ViewChild,
   ElementRef
 } from '@angular/core';
+import { Router, IsActiveMatchOptions } from '@angular/router';
 import { DSSizes } from '../../../../shared/constants/jl-components.constants';
 import { Component, OnInit } from '@angular/core';
 import {
@@ -66,12 +67,21 @@ export class navItemNavComponent implements OnInit {
     children: []
   };
 
+  // Check if current url's fragment match
+  fragMatchOptions: IsActiveMatchOptions = {
+      queryParams: 'ignored',
+      matrixParams: 'exact',
+      paths: 'exact',
+      fragment: 'exact'
+  };
+
   navObjectChangeSub = new Subscription();
 
   constructor(
     private renderer: Renderer2,
     private navEvent: NavigationService,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private router: Router
   ) {}
 
   ngOnInit() {

--- a/component-library/component-lib/src/lib/shared/navigation/nav-item-nav/nav-item-nav.component.ts
+++ b/component-library/component-lib/src/lib/shared/navigation/nav-item-nav/nav-item-nav.component.ts
@@ -80,8 +80,7 @@ export class navItemNavComponent implements OnInit {
   constructor(
     private renderer: Renderer2,
     private navEvent: NavigationService,
-    private cdr: ChangeDetectorRef,
-    private router: Router
+    private cdr: ChangeDetectorRef
   ) {}
 
   ngOnInit() {

--- a/component-library/component-lib/src/lib/shared/navigation/nav-item-nav/nav-item-nav.component.ts
+++ b/component-library/component-lib/src/lib/shared/navigation/nav-item-nav/nav-item-nav.component.ts
@@ -6,7 +6,7 @@ import {
   ViewChild,
   ElementRef
 } from '@angular/core';
-import { Router, IsActiveMatchOptions } from '@angular/router';
+import { IsActiveMatchOptions } from '@angular/router';
 import { DSSizes } from '../../../../shared/constants/jl-components.constants';
 import { Component, OnInit } from '@angular/core';
 import {

--- a/component-library/component-lib/src/lib/shared/progress-tags/progress-tags.component.ts
+++ b/component-library/component-lib/src/lib/shared/progress-tags/progress-tags.component.ts
@@ -3,7 +3,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { DSSizes } from '../../../shared/constants/jl-components.constants';
 
 export const TAG_LABELS_EN = [
-  'In Progress',
+  'In progress',
   'Completed',
   'Error',
   'Locked',

--- a/core-library/component-styling/icon/_icon.scss
+++ b/core-library/component-styling/icon/_icon.scss
@@ -16,15 +16,15 @@
 
 @mixin large-styles() {
   svg {
-    height: 20px;
-    width: 20px;
+    height: 24px;
+    width: 24px;
   }
 }
 
 @mixin small-styles() {
   svg {
-    height: 16px;
-    width: 16px;
+    height: 20px;
+    width: 20px;
   }
 }
 

--- a/core-library/component-styling/progress-indicator/_progress-indicator.scss
+++ b/core-library/component-styling/progress-indicator/_progress-indicator.scss
@@ -23,34 +23,34 @@
 
 @mixin large-styles() {
   button.tags-btn {
-    @include typography.fontSet(body, 3, regular);
+    @include typography.fontSet(body, 3, emphasis);
     &:where([selected])::after {
       transform: translateY(sizes.$fixed-0);
     }
   }
   button.tags-btn-plus {
-    @include typography.fontSet(body, 3, regular);
+    @include typography.fontSet(body, 3, emphasis);
     padding-bottom: 4px;
   }
   .stepTitle {
-    @include typography.fontSet(heading, 5, regular);
+    @include typography.fontSet(heading, 5, emphasis);
     margin-bottom: 8px;
   }
 }
 
 @mixin small-styles() {
   button.tags-btn {
-    @include typography.fontSet(body, 4, regular);
+    @include typography.fontSet(body, 4, emphasis);
     &:where([selected])::after {
       transform: translateY(sizes.$fixed-0);
     }
   }
   button.tags-btn-plus {
-    @include typography.fontSet(body, 4, regular);
+    @include typography.fontSet(body, 4, emphasis);
     padding-bottom: 4px;
   }
   .stepTitle {
-    @include typography.fontSet(heading, 6, regular);
+    @include typography.fontSet(heading, 6, emphasis);
     margin-bottom: 4px;
   }
 }

--- a/core-library/component-styling/progress-tags/_progress-tags.scss
+++ b/core-library/component-styling/progress-tags/_progress-tags.scss
@@ -40,8 +40,7 @@
     font-weight: 400;
   }
   .content {
-    margin-left: 6px;
-    @include typography.fontSet(body, 3, regular);
+    @include typography.fontSet(body, 3, emphasis);
   }
 }
 
@@ -56,8 +55,7 @@
     font-weight: 400;
   }
   .content {
-    margin-left: 5px;
-    @include typography.fontSet(body, 4, regular);
+    @include typography.fontSet(body, 4, emphasis);
   }
 }
 
@@ -106,6 +104,7 @@
       align-items: center;
       display: flex;
       .content {
+        margin-left: 4px;
         white-space: nowrap;
       }
     }

--- a/core-library/tokens/_text.scss
+++ b/core-library/tokens/_text.scss
@@ -66,7 +66,7 @@ $body: (
     ),
     weight: (
         regular: 400,
-        emphasis: 600,
+        emphasis: 700,
     ),
     family: 'Inter',
 );


### PR DESCRIPTION
**PR Approval Template**
**Why are these changes introduced?**
* Related story #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/922205))

**What is this pull request doing?**
* adds router link active options to match path and fragments in order to apply the active-link class
* passes these options into the template
* TO TEST: Need two or more nav item links to share the same href with unique anchor tags. When clicked, where an anchor tag exists, only the selected item will be active, rather than any/all sharing that same href.
* For example:
  
  forDeveloperPage: INavigationItemLink = {
    id: 'forDeveloperPagenNavItem',
    label: 'For developers',
    type: 'link',
    children: [],
    **anchor: 'forDevelopers',
    href: 'ROUTES.forDevelopers'**
  };

  forDesignersPage: INavigationItemLink = {
    id: 'forDesignersPageNavItem',
    label: 'For designers',
    type: 'link',
    children: [],
    **anchor: 'forDesigners',
    href: 'ROUTES.forDevelopers'**
  };