### PR TITLE
Issue with Content Container on Input Documentation Page

### DIFF
--- a/component-library/src/app/components/code-viewer/code-viewer.component.scss
+++ b/component-library/src/app/components/code-viewer/code-viewer.component.scss
@@ -21,6 +21,7 @@ $selectors: 'app-code-viewer';
   display: block;
 
   .code-viewer {
+    box-sizing: border-box;
     border: 1px solid var(--border);
     border-radius: 8px;
     width: 100%;

--- a/component-library/src/app/shell/shell.component.scss
+++ b/component-library/src/app/shell/shell.component.scss
@@ -1,8 +1,9 @@
-@use '~@ircc-ca/ds-sdc-core/typography/typography';
-@use '../../../../core-library/tokens/sizes';
-@use '../../../../core-library/util/device';
-@use '../../../../core-library/util/color' as color;
-@import '../../scss/grid';
+@use "@ircc-ca/ds-sdc-core/typography/typography";
+@use "../../../../core-library/tokens/sizes";
+@use "../../../../core-library/util/device";
+@use "../../../../core-library/util/color" as color;
+
+@import "../../scss/grid";
 
 $page-width: 1440px;
 $tablet-padding: 24px;
@@ -73,6 +74,7 @@ $mobile-padding: 16px;
 
     @include in-desktop-layout {
       @include col-2;
+
       margin-right: -1px;
     }
 
@@ -85,14 +87,13 @@ $mobile-padding: 16px;
     box-sizing: border-box;
     min-height: calc(100vh - 60px);
 
-    @include col-12;
-
     @include in-tablet-layout {
       @include col-12;
     }
 
     @include up-laptop-layout {
-      @include col-10;
+      width: 100%;
+      max-width: calc(100% - 276px);
       padding-left: sizes.$fixed-36;
     }
 
@@ -102,6 +103,7 @@ $mobile-padding: 16px;
 
     @include un-tablet-layout {
       @include col-12;
+
       padding: 0 $tablet-padding;
     }
 
@@ -117,7 +119,8 @@ $mobile-padding: 16px;
 
       .date-modified {
         @include typography.fontSet(body, 3, regular);
-        padding: 14px 0 10px 0;
+
+        padding: 14px 0 10px;
         margin: 0;
       }
     }

--- a/core-library/component-styling/icon-button/_icon-button.scss
+++ b/core-library/component-styling/icon-button/_icon-button.scss
@@ -22,7 +22,7 @@
 
 @mixin primary-lg {
   svg {
-    height: 23px;
+    height: 24px; // Test to verify blurry issue on Mac
   }
 }
 

--- a/core-library/component-styling/icon-button/_icon-button.scss
+++ b/core-library/component-styling/icon-button/_icon-button.scss
@@ -22,7 +22,7 @@
 
 @mixin primary-lg {
   svg {
-    height: 24px; // Test to verify blurry issue on Mac
+    height: 24px;
   }
 }
 


### PR DESCRIPTION
Why are these changes introduced?
- Related story [924002](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/924002)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-page_container/en/input-documentation)

What is this pull request doing?

- Page container: fix cut off issue
- Button icon: set icon `X` height back to 24px as blurry issue does not exist on QA's Mac

Reviewer checklist:

1. Go to [input page](https://d1whfh0luwluq8.cloudfront.net/qa-page_container/en/input-documentation) or any other component page
2. Shrink screen to check if content area is cutting off