### PR TITLE
Bug 924009 Doc Site overall content margin issue

### DIFF
--- a/component-library/src/app/pages/banner-documentation/banner-doc-code.component.html
+++ b/component-library/src/app/pages/banner-documentation/banner-doc-code.component.html
@@ -1,26 +1,22 @@
-<div class="content-doc-wrapper col-12 col-lg-10">
-  <div style="width: 100%">
-    <app-interactive-demo componentType="banner">
-      <ircc-cl-lib-tabs
-        tabs
-        (valueChange)="setBannerType($event)"
-        [config]="demoTabsConfig"
-      >
-      </ircc-cl-lib-tabs>
-      <div
-        component
-        class="banner-container"
-        #banner
-      >
-        <ircc-cl-lib-banner [config]="bannerConfig"></ircc-cl-lib-banner>
-      </div>
-      <ng-container
-        toggles
-        *ngFor="let toggle of toggles"
-      >
-        <ircc-cl-lib-radio-input [config]="toggle"></ircc-cl-lib-radio-input>
-      </ng-container>
-    </app-interactive-demo>
+<app-interactive-demo componentType="banner">
+  <ircc-cl-lib-tabs
+    tabs
+    (valueChange)="setBannerType($event)"
+    [config]="demoTabsConfig"
+  >
+  </ircc-cl-lib-tabs>
+  <div
+    component
+    class="banner-container"
+    #banner
+  >
+    <ircc-cl-lib-banner [config]="bannerConfig"></ircc-cl-lib-banner>
   </div>
-  <app-code-viewer [config]="codeViewConfig"></app-code-viewer>
-</div>
+  <ng-container
+    toggles
+    *ngFor="let toggle of toggles"
+  >
+    <ircc-cl-lib-radio-input [config]="toggle"></ircc-cl-lib-radio-input>
+  </ng-container>
+</app-interactive-demo>
+<app-code-viewer [config]="codeViewConfig"></app-code-viewer>

--- a/component-library/src/app/pages/code-view/code-view.component.ts
+++ b/component-library/src/app/pages/code-view/code-view.component.ts
@@ -6,7 +6,7 @@ import { TranslatedPageComponent } from '../translated-page-component';
 import { ICodeViewerConfig } from '@app/components/code-viewer/code-viewer.component';
 
 @Component({
-  selector: 'app-codeview',
+  selector: 'app-code-view',
   templateUrl: './code-view.component.html',
   styleUrls: ['./code-view.component.scss'],
   providers: [SlugifyPipe]

--- a/component-library/src/app/pages/code-view/code-view.component.ts
+++ b/component-library/src/app/pages/code-view/code-view.component.ts
@@ -6,7 +6,7 @@ import { TranslatedPageComponent } from '../translated-page-component';
 import { ICodeViewerConfig } from '@app/components/code-viewer/code-viewer.component';
 
 @Component({
-  selector: 'app-overview',
+  selector: 'app-codeview',
   templateUrl: './code-view.component.html',
   styleUrls: ['./code-view.component.scss'],
   providers: [SlugifyPipe]

--- a/component-library/src/app/pages/icon-button-documentation/icon-button-doc-code.component.html
+++ b/component-library/src/app/pages/icon-button-documentation/icon-button-doc-code.component.html
@@ -1,30 +1,24 @@
-<div class="content-doc-wrapper col-12 col-lg-10">
-  <div style="width: 100%">
-    <app-interactive-demo componentType="iconBtn">
-      <ircc-cl-lib-tabs
-        tabs
-        (valueChange)="setIconBtnCategory($event)"
-        [config]="demoTabsConfig"
-      >
-      </ircc-cl-lib-tabs>
-      <div
-        component
-        class="icon-btn-container"
-        #iconButton
-      >
-        <ircc-cl-lib-icon-button
-          [config]="iconBtnConfig"
-        ></ircc-cl-lib-icon-button>
-      </div>
-      <ng-container toggles>
-        <ng-container *ngFor="let toggle of toggles">
-          <ircc-cl-lib-radio-input [config]="toggle"></ircc-cl-lib-radio-input>
-        </ng-container>
-        <ng-container *ngFor="let checkbox of checkboxes">
-          <ircc-cl-lib-checkbox [config]="checkbox"></ircc-cl-lib-checkbox>
-        </ng-container>
-      </ng-container>
-    </app-interactive-demo>
+<app-interactive-demo componentType="iconBtn">
+  <ircc-cl-lib-tabs
+    tabs
+    (valueChange)="setIconBtnCategory($event)"
+    [config]="demoTabsConfig"
+  >
+  </ircc-cl-lib-tabs>
+  <div
+    component
+    class="icon-btn-container"
+    #iconButton
+  >
+    <ircc-cl-lib-icon-button [config]="iconBtnConfig"></ircc-cl-lib-icon-button>
   </div>
-  <app-code-viewer [config]="codeViewConfig"></app-code-viewer>
-</div>
+  <ng-container toggles>
+    <ng-container *ngFor="let toggle of toggles">
+      <ircc-cl-lib-radio-input [config]="toggle"></ircc-cl-lib-radio-input>
+    </ng-container>
+    <ng-container *ngFor="let checkbox of checkboxes">
+      <ircc-cl-lib-checkbox [config]="checkbox"></ircc-cl-lib-checkbox>
+    </ng-container>
+  </ng-container>
+</app-interactive-demo>
+<app-code-viewer [config]="codeViewConfig"></app-code-viewer>

--- a/component-library/src/app/pages/overview/overview.component.html
+++ b/component-library/src/app/pages/overview/overview.component.html
@@ -1,4 +1,4 @@
-<div class="content-doc-wrapper col-12 col-lg-10">
+<div class="content-doc-wrapper">
   <app-title-slug-url
     [config]="overViewSlugTitleURLConfig"
   ></app-title-slug-url>

--- a/component-library/src/app/shell/shell.component.scss
+++ b/component-library/src/app/shell/shell.component.scss
@@ -47,6 +47,10 @@ $mobile-padding: 16px;
   }
 }
 
+.content-area-responsive {
+  justify-content: flex-start;
+}
+
 .main-container {
   &.nav-open {
     display: flex;
@@ -113,7 +117,6 @@ $mobile-padding: 16px;
 
     .date-modified-container {
       width: 872px;
-      margin: auto;
       margin-top: 80px;
       margin-bottom: 48px;
 


### PR DESCRIPTION
**PR Approval Template**
**Why are these changes introduced?**
* Related story -URL(https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/924009)

**What is this pull request doing?**
* removed extra divs and inline styles in banner and icon-btn interactive demo/code block pages to align them with all the other documentation pages
* Fixes the code-view selector from 'app-overview' (which already exists) to app-code-view
* Changes content-area responsive to flex-start to align according to design
* Remove auto margin from footer to align with container

**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)

** File names and hierarchies are in keeping with our norms:
* Interfaces start with 'I' followed by a capital letter and camel case (IInterfaceExample) and are descriptive
* Subjects are suffixed with 'Subj' (ex: thisIsAnExampleSubj)
* Subscriptions are suffixed with 'Sub' (ex: thisIsAnExampleSub)
* Observables ere suffixed with 'Obs$' (ex: thisIsAnExampleObs$)
* Class and variable names are camel case
* Class names should start with a capital letter (i.e. ExampleClass)
* Variable names should start with a lower case letter (i.e thisIsAnExampleVariable)
* All caps and underscores are used for exported constants (THIS_IS_A_CONSTANT)
* Names are all spelled correctly
* ngOnInit and constructor is removed when not used
* ':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?

**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.