### PR TITLE
fix breadcrumb alignment on keyboard focus

### DIFF
--- a/core-library/component-styling/breadcrumb/_breadcrumb.scss
+++ b/core-library/component-styling/breadcrumb/_breadcrumb.scss
@@ -72,7 +72,7 @@
     }
 
     &.breadcrumb-root {
-      padding: 4px 8px 4px 0;
+      padding: 4px 8px;
     }
   }
 


### PR DESCRIPTION
**Why are these changes introduced?**
* Related story #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/924146))

**What is this pull request doing?**
* Updated padding to the breadcrump to align content centered on keyboard focus