### PR TITLE
Bug/input page

### DIFF
--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -84,11 +84,11 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
       label: 'General.Hint',
       options: [
         {
-          text: 'General.Show',
+          text: 'General.TrueLabel',
           value: 'True'
         },
         {
-          text: 'General.Hide',
+          text: 'General.FalseLabel',
           value: 'False'
         }
       ]
@@ -114,13 +114,16 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
       label: 'ERROR.errorMessage',
       options: [
         {
-          text: 'None'
+          text: 'General.FalseLabel',
+          value: 'None'
         },
         {
-          text: 'Single'
+          text: 'General.MultipleErrors',
+          value: 'Multiple'
         },
         {
-          text: 'Multiple'
+          text: 'General.TrueLabel',
+          value: 'Single'
         }
       ]
     },
@@ -131,11 +134,11 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
       label: 'General.Description',
       options: [
         {
-          text: 'General.Show',
+          text: 'General.TrueLabel',
           value: 'True'
         },
         {
-          text: 'General.Hide',
+          text: 'General.FalseLabel',
           value: 'False'
         }
       ]
@@ -147,11 +150,11 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
       label: 'General.Placeholder',
       options: [
         {
-          text: 'General.Show',
+          text: 'General.TrueLabel',
           value: 'True'
         },
         {
-          text: 'General.Hide',
+          text: 'General.FalseLabel',
           value: 'False'
         }
       ]
@@ -226,17 +229,14 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     this.inputConfig = {
       ...this.inputConfig,
       type: value == 'password' ? 'password' : 'text',
-      label: value == 'password' ? 'Password' : 'Label text'
     };
     this.inputConfigSingle = {
       ...this.inputConfigSingle,
       type: value == 'password' ? 'password' : 'text',
-      label: value == 'password' ? 'Password' : 'Label text'
     };
     this.inputConfigMulti = {
       ...this.inputConfigMulti,
       type: value == 'password' ? 'password' : 'text',
-      label: value == 'password' ? 'Password' : 'Label text'
     };
 
     this.parseCodeViewConfig();

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -228,15 +228,15 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
   setInputType(value: any) {
     this.inputConfig = {
       ...this.inputConfig,
-      type: value == 'password' ? 'password' : 'text',
+      type: value == 'password' ? 'password' : 'text'
     };
     this.inputConfigSingle = {
       ...this.inputConfigSingle,
-      type: value == 'password' ? 'password' : 'text',
+      type: value == 'password' ? 'password' : 'text'
     };
     this.inputConfigMulti = {
       ...this.inputConfigMulti,
-      type: value == 'password' ? 'password' : 'text',
+      type: value == 'password' ? 'password' : 'text'
     };
 
     this.parseCodeViewConfig();

--- a/component-library/src/app/pages/input-documentation/input-documentation.component.html
+++ b/component-library/src/app/pages/input-documentation/input-documentation.component.html
@@ -6,7 +6,7 @@
     <app-title-slug-url
       [config]="headingConfig.interactiveDemoSlugConfig"
     ></app-title-slug-url>
-    <p class="body3 demo">{{ 'Input.InteractiveDemoDesc' | translate }}</p>
+    <p class="body3 demo" [innerHTML]="'Input.InteractiveDemoDesc' | translate"></p>
     <app-input-doc-code></app-input-doc-code>
   </section>
 

--- a/component-library/src/app/pages/input-documentation/input-documentation.component.html
+++ b/component-library/src/app/pages/input-documentation/input-documentation.component.html
@@ -6,7 +6,10 @@
     <app-title-slug-url
       [config]="headingConfig.interactiveDemoSlugConfig"
     ></app-title-slug-url>
-    <p class="body3 demo" [innerHTML]="'Input.InteractiveDemoDesc' | translate"></p>
+    <p
+      class="body3 demo"
+      [innerHTML]="'Input.InteractiveDemoDesc' | translate"
+    ></p>
     <app-input-doc-code></app-input-doc-code>
   </section>
 

--- a/component-library/src/assets/locales/en.json
+++ b/component-library/src/assets/locales/en.json
@@ -362,7 +362,7 @@
 		"fieldExceededMaxLength": "This field has exceeded max length.",
 		"requiredTextAreaError": "This field is required.",
 		"testErrorMessage": "Test error message.",
-		"errorMessage": "Error message",
+		"errorMessage": "Error",
 		"requiredRadioError": "No selection has been made. Please select an option",
 		"WritingErrHeading": "Writing error messages"
 	},
@@ -478,7 +478,7 @@
 	"Input": {
 		"Title": "Input",
 		"Intro": "The input component provides fields that allow users to enter information. The input component provides several configurable options to clearly communicate form requirements for many use-cases.",
-		"InteractiveDemoDesc": "Try our input component and the configurable options available within it.",
+		"InteractiveDemoDesc": "Try our <strong>input</strong> component and the configurable options available within it.",
 		"PrimaryHeading": "Basic input",
 		"SecondaryHeading": "Password input",
 		"PrimaryText": "The basic input allows for entry of single-line information. The form component is configurable to fit various use cases and layouts. See available configurations below.",
@@ -828,6 +828,7 @@
 		"NoneErr": "None",
 		"SingleErr": "Single",
 		"MultipleErr": "Multiple",
+		"MultipleErrors": "Multiple errors",
 		"Placeholder": "Placeholder",
 		"Basic": "Basic",
 		"Password": "Password",

--- a/component-library/src/assets/locales/fr.json
+++ b/component-library/src/assets/locales/fr.json
@@ -362,7 +362,7 @@
 		"fieldExceededMaxLength": "Ce champ a dépassé la longueur maximale.",
 		"requiredTextAreaError": "[FR] This field is required.",
 		"testErrorMessage": "Tester le message d'erreur.",
-		"errorMessage": "Message d'erreur",
+		"errorMessage": "D'erreur",
 		"requiredRadioError": "[FR] No selection has been made. Please select an option",
 		"WritingErrHeading": "[FR] Writing error messages"
 	},
@@ -478,7 +478,7 @@
 	"Input": {
 		"Title": "Input",
 		"Intro": "The input component provides fields that allow users to enter information. The input component provides several configurable options to clearly communicate form requirements for many use-cases.",
-		"InteractiveDemoDesc": "Try our input component and the configurable options available within it.",
+		"InteractiveDemoDesc": "Try our <strong>input</strong> component and the configurable options available within it.",
 		"PrimaryHeading": "Basic input",
 		"SecondaryHeading": "Password input",
 		"PrimaryText": "The basic input allows for entry of single-line information. The form component is configurable to fit various use cases and layouts. See available configurations below.",
@@ -828,6 +828,7 @@
 		"NoneErr": "[FR] None",
 		"SingleErr": "[FR] Single",
 		"MultipleErr": "[FR] Multiple",
+		"MultipleErrors": "[FR] Multiple errors",
 		"Placeholder": "[FR] Placeholder",
 		"Basic": "[FR] Basic",
 		"Password": "[FR] Password",

--- a/core-library/tokens/input/_input-const.scss
+++ b/core-library/tokens/input/_input-const.scss
@@ -27,6 +27,7 @@
 
   &::placeholder {
     color: var(--text-placeholder);
+    opacity: 1;//To fix the color opacity issue on Firefox
   }
 }
 
@@ -52,6 +53,9 @@
   &:disabled {
     border-color: var(--border-disabled);
     color: var(--text-disabled);
+    &::placeholder {
+      color: var(--text-disabled);
+    }
   }
 }
 


### PR DESCRIPTION
**Why are these changes introduced?**
* Related story #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/919622))
* DOES NOT INCLUDE state: disabled in the code block and comment being handled in a tech debt story now.

**What is this pull request doing?**
* Bug fixes to the input documentation page
* Fixes placeholder text disabled color with firefox support
* Updates label text per design spec
* Updates toggles to match design with translation support
* Add strong tag to interactive demo description

**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)

** File names and hierarchies are in keeping with our norms:
* Interfaces start with 'I' followed by a capital letter and camel case (IInterfaceExample) and are descriptive
* Subjects are suffixed with 'Subj' (ex: thisIsAnExampleSubj)
* Subscriptions are suffixed with 'Sub' (ex: thisIsAnExampleSub)
* Observables ere suffixed with 'Obs$' (ex: thisIsAnExampleObs$)
* Class and variable names are camel case
* Class names should start with a capital letter (i.e. ExampleClass)
* Variable names should start with a lower case letter (i.e thisIsAnExampleVariable)
* All caps and underscores are used for exported constants (THIS_IS_A_CONSTANT)
* Names are all spelled correctly
* ngOnInit and constructor is removed when not used
* ':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?

**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.