### PR TITLE
bug: request form banner height and side navs

### DIFF
--- a/component-library/src/app/components/side-nav/side-nav.config.ts
+++ b/component-library/src/app/components/side-nav/side-nav.config.ts
@@ -80,6 +80,17 @@ export class SideNavConfig {
         type: ItemType.Link,
         category: ItemCategory.subTitle,
         path: 'ROUTES.buttons'
+      },
+      {
+        text: 'LeftSideNav.title.support',
+        type: ItemType.Link,
+        category: ItemCategory.Title
+      },
+      {
+        text: 'RequestForm.Title',
+        type: ItemType.Link,
+        category: ItemCategory.subTitle,
+        path: 'ROUTES.requestForm'
       }
     ];
   }

--- a/component-library/src/app/pages/QA/accessibility-demo/accessibility-demo-next-page/accessibility-demo-next-page.component.ts
+++ b/component-library/src/app/pages/QA/accessibility-demo/accessibility-demo-next-page/accessibility-demo-next-page.component.ts
@@ -63,7 +63,6 @@ export class AccessibilityDemoNextPageComponent implements OnInit, OnDestroy {
       });
   }
 
-
   progressTabButtonEvent(event: Event) {
     const eventInt = parseInt(event.toString());
     if (this.progressIndicatorConfig.selected !== undefined) {

--- a/component-library/src/app/pages/request-form/request-form.component.html
+++ b/component-library/src/app/pages/request-form/request-form.component.html
@@ -1,4 +1,4 @@
-<div class="content-doc-wrapper">
+<div class="content-doc-wrapper col-12 col-lg-9 col-xl-10">
   <app-title-slug-url
     [config]="submitRequestTitleSlugConfig"
     class="h1 emphasis"
@@ -97,3 +97,7 @@
     </div>
   </section>
 </div>
+<app-side-nav
+  class="right-nav col-12 col-lg-3 col-xl-2"
+  [navBarData]="rightNavData"
+></app-side-nav>

--- a/component-library/src/app/pages/request-form/request-form.component.html
+++ b/component-library/src/app/pages/request-form/request-form.component.html
@@ -4,7 +4,7 @@
     class="h1 emphasis"
   ></app-title-slug-url>
   <p class="body1 intro">{{ 'RequestForm.Intro' | translate }}</p>
-  <div class="banner-container">
+  <div class="banner-wrapper">
     <ircc-cl-lib-banner [config]="bannerConfig"></ircc-cl-lib-banner>
   </div>
 

--- a/component-library/src/app/pages/request-form/request-form.component.scss
+++ b/component-library/src/app/pages/request-form/request-form.component.scss
@@ -63,10 +63,11 @@ h3 {
 
 }
 
-.banner-container {
+.banner-wrapper {
   margin-top: 24px;
   max-width: 552px;
   height: 84px;
+  line-height: 20px;
 }
 
 .submit-request-container {

--- a/component-library/src/app/pages/request-form/request-form.component.scss
+++ b/component-library/src/app/pages/request-form/request-form.component.scss
@@ -1,5 +1,10 @@
 @use "../../../../../core-library/util/device" as device;
 @use '@ircc-ca/ds-sdc-core/typography/typography';
+@use 'src/scss/grid';
+
+:host {
+  @include grid.row;
+}
 
 .content-doc-wrapper {
   box-sizing: border-box;

--- a/component-library/src/app/pages/request-form/request-form.component.ts
+++ b/component-library/src/app/pages/request-form/request-form.component.ts
@@ -62,8 +62,7 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
     type: 'info',
     rounded: false,
     dismissible: false,
-    size: 'small',
-    cta: []
+    size: 'small'
   };
 
   typeOfRequestRadioConfig: IRadioInputComponentConfig = {

--- a/component-library/src/app/pages/request-form/request-form.component.ts
+++ b/component-library/src/app/pages/request-form/request-form.component.ts
@@ -23,6 +23,8 @@ import { SlugifyPipe } from '@app/share/pipe-slugify.pipe';
 import { TranslateService } from '@app/share/templates/parent-template.module';
 import { first } from 'rxjs/operators';
 import { HttpErrorResponse } from '@angular/common/http';
+import { ISideNavDataInterface } from '@app/components/side-nav/side-nav.model';
+import { SideNavConfig } from '@app/components/side-nav/side-nav.config';
 
 @Component({
   selector: 'app-request-form',
@@ -31,6 +33,14 @@ import { HttpErrorResponse } from '@angular/common/http';
   providers: [SlugifyPipe]
 })
 export class RequestFormComponent implements OnInit, AfterViewInit {
+  rightNavData: ISideNavDataInterface[];
+  rightNavDataRaw: string[] = [
+    // list of all right nav items
+    'RequestForm.Title',
+    'RequestForm.RequestCriteriaTitle',
+    'General.RequestFormTitle'
+  ];
+
   altLangLink = 'requestForm';
   form = new FormGroup({});
   showUseCase: boolean = false;
@@ -247,8 +257,13 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
   constructor(
     private translate: TranslateService,
     private lang: LangSwitchService,
-    private requestFormService: RequestFormService
-  ) {}
+    private requestFormService: RequestFormService,
+    private navBarConfig: SideNavConfig
+  ) {
+    this.rightNavData = this.navBarConfig.getRightNavBarConfig(
+      this.rightNavDataRaw
+    );
+  }
   ngAfterViewInit(): void {
     /**
      * Set local storage form data when form values change after init so we're not setting and getting at the same time

--- a/component-library/src/app/shell/shell.component.ts
+++ b/component-library/src/app/shell/shell.component.ts
@@ -127,12 +127,7 @@ export class ShellComponent implements OnInit {
     id: 'gettingStartedNavAccordian',
     label: 'Getting Started',
     type: 'accordion',
-    children: [
-      this.overviewPage,
-      this.forDeveloperPage,
-      this.forDesignersPage,
-      this.requestFormPage
-    ]
+    children: [this.overviewPage, this.forDeveloperPage, this.forDesignersPage]
   };
 
   foundationsNav: INavigationItemAccordion = {
@@ -155,6 +150,14 @@ export class ShellComponent implements OnInit {
       this.datePickerPage,
       this.iconBtnPage
     ]
+  };
+
+  supportNav: INavigationItemAccordion = {
+    open: true,
+    id: 'supportNavAccordian',
+    label: 'Support',
+    type: 'accordion',
+    children: [this.requestFormPage]
   };
 
   requiredPDF: INavigationItemLink = {
@@ -184,7 +187,8 @@ export class ShellComponent implements OnInit {
     navigationConfig: [
       this.gettingStartedNav,
       this.foundationsNav,
-      this.componentNav
+      this.componentNav,
+      this.supportNav
     ]
   };
 


### PR DESCRIPTION
**Why are these changes introduced?**
* Related story #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/924652))

**What is this pull request doing?**
* Removes CTA from config which was adding extra margin to the banner container
* Adds new 'Support' section in the left side nav with the request form as a child item
* Adds right side nav to page
* *Does Not** refactor the content container margins - this is captured in a different story 

**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)

** File names and hierarchies are in keeping with our norms:
* Interfaces start with 'I' followed by a capital letter and camel case (IInterfaceExample) and are descriptive
* Subjects are suffixed with 'Subj' (ex: thisIsAnExampleSubj)
* Subscriptions are suffixed with 'Sub' (ex: thisIsAnExampleSub)
* Observables ere suffixed with 'Obs$' (ex: thisIsAnExampleObs$)
* Class and variable names are camel case
* Class names should start with a capital letter (i.e. ExampleClass)
* Variable names should start with a lower case letter (i.e thisIsAnExampleVariable)
* All caps and underscores are used for exported constants (THIS_IS_A_CONSTANT)
* Names are all spelled correctly
* ngOnInit and constructor is removed when not used
* ':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?

**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.