### PR TITLE
Banner Documentation Font Weight Fix

### DIFF
--- a/component-library/src/app/pages/banner-documentation/banner-documentation.component.html
+++ b/component-library/src/app/pages/banner-documentation/banner-documentation.component.html
@@ -20,7 +20,7 @@
     <div class="wrapper-container">
       <!-- Info Banner Preview -->
       <div class="element-wrapper-container">
-        <h3 class="h5 sub-headings">
+        <h3 class="sub-headings">
           {{ 'General.InfoHeading' | translate }}
         </h3>
         <app-component-preview
@@ -40,7 +40,7 @@
       </div>
       <!-- Warning Banner Preview -->
       <div class="element-wrapper-container">
-        <h3 class="h5 sub-headings">
+        <h3 class="sub-headings">
           {{ 'General.WarningHeading' | translate }}
         </h3>
         <app-component-preview
@@ -60,7 +60,7 @@
       </div>
       <!-- Critical Banner Preview -->
       <div class="element-wrapper-container">
-        <h3 class="h5 sub-headings">
+        <h3 class="sub-headings">
           {{ 'General.Critical' | translate }}
         </h3>
         <app-component-preview
@@ -80,7 +80,7 @@
       </div>
       <!-- Success Banner Preview -->
       <div class="element-wrapper-container">
-        <h3 class="h5 sub-headings">
+        <h3 class="sub-headings">
           {{ 'General.SuccessHeading' | translate }}
         </h3>
         <app-component-preview
@@ -100,7 +100,7 @@
       </div>
       <!-- Generic Banner Preview -->
       <div class="element-wrapper-container">
-        <h3 class="h5 sub-headings">
+        <h3 class="sub-headings">
           {{ 'General.GenericHeading' | translate }}
         </h3>
         <app-component-preview
@@ -129,7 +129,7 @@
       <div class="element-wrapper-container">
         <div class="row">
           <div class="col-12 col-md-6">
-            <h3 class="h5 sub-headings">
+            <h3 class="sub-headings">
               {{ 'General.Size' | translate }}
             </h3>
             <ul>
@@ -138,7 +138,7 @@
             </ul>
           </div>
           <div class="col-12 col-md-6">
-            <h3 class="h5 sub-headings">
+            <h3 class="sub-headings">
               {{ 'General.TypesHeading' | translate }}
             </h3>
             <ul>
@@ -154,7 +154,7 @@
       <div class="element-wrapper-container">
         <div class="row">
           <div class="col-12 col-md-6">
-            <h3 class="h5 sub-headings">
+            <h3 class="sub-headings">
               {{ 'General.StateLabel' | translate }}
             </h3>
             <ul>
@@ -166,7 +166,7 @@
             </ul>
           </div>
           <div class="col-12 col-md-6">
-            <h3 class="h5 sub-headings">
+            <h3 class="sub-headings">
               {{ 'General.Description' | translate }}
             </h3>
             <ul>
@@ -179,7 +179,7 @@
       <div class="element-wrapper-container">
         <div class="row">
           <div class="col-12 col-md-6">
-            <h3 class="h5 sub-headings">
+            <h3 class="sub-headings">
               {{ 'General.TitleLabel' | translate }}
             </h3>
             <ul>
@@ -188,7 +188,7 @@
             </ul>
           </div>
           <div class="col-12 col-md-6">
-            <h3 class="h5 sub-headings">
+            <h3 class="sub-headings">
               {{ 'General.CloseLabel' | translate }}
             </h3>
             <ul>
@@ -201,7 +201,7 @@
       <div class="element-wrapper-container">
         <div class="row">
           <div class="col-12 col-md-6">
-            <h3 class="h5 sub-headings">
+            <h3 class="sub-headings">
               {{ 'Banner.BannerConfig.CTA1Label' | translate }}
             </h3>
             <ul>
@@ -210,7 +210,7 @@
             </ul>
           </div>
           <div class="col-12 col-md-6">
-            <h3 class="h5 sub-headings">
+            <h3 class="sub-headings">
               {{ 'Banner.BannerConfig.CTA2Label' | translate }}
             </h3>
             <ul>
@@ -223,7 +223,7 @@
       <div class="element-wrapper-container">
         <div class="row">
           <div class="col-12 col-md-6">
-            <h3 class="h5 sub-headings">
+            <h3 class="sub-headings">
               {{ 'Banner.BannerConfig.CTA3Label' | translate }}
             </h3>
             <ul>
@@ -243,7 +243,7 @@
 
     <div class="wrapper-container">
       <div class="element-wrapper-container">
-        <h3 class="h5 emphasis sub-headings">
+        <h3 class="emphasis sub-headings">
           {{ 'Banner.DesignGuideLines.KeepActionsSimpleLabel' | translate }}
         </h3>
         <div class="row">
@@ -256,7 +256,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-green"
+                class="do-dont-heading emphasis text-underline text-color-green"
               >
                 {{ 'General.DoHeading' | translate }}
               </h4>
@@ -274,7 +274,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-red"
+                class="do-dont-heading emphasis text-underline text-color-red"
               >
                 {{ 'General.DontHeading' | translate }}
               </h4>
@@ -288,7 +288,7 @@
         </div>
       </div>
       <div class="element-wrapper-container mt_8">
-        <h3 class="h5 emphasis sub-headings">
+        <h3 class="emphasis sub-headings">
           {{ 'Banner.DesignGuideLines.UseOneBannerAtATimeLabel' | translate }}
         </h3>
         <div class="row">
@@ -299,7 +299,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-green"
+                class="do-dont-heading emphasis text-underline text-color-green"
               >
                 {{ 'General.DoHeading' | translate }}
               </h4>
@@ -317,7 +317,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-red"
+                class="do-dont-heading emphasis text-underline text-color-red"
               >
                 {{ 'General.DontHeading' | translate }}
               </h4>
@@ -329,7 +329,7 @@
         </div>
       </div>
       <div class="element-wrapper-container mt_8">
-        <h3 class="h5 emphasis sub-headings">
+        <h3 class="emphasis sub-headings">
           {{ 'Banner.DesignGuideLines.ShowMaximumButtonsLabel' | translate }}
         </h3>
         <div class="row">
@@ -342,7 +342,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-green"
+                class="do-dont-heading emphasis text-underline text-color-green"
               >
                 {{ 'General.DoHeading' | translate }}
               </h4>
@@ -362,7 +362,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-red"
+                class="do-dont-heading emphasis text-underline text-color-red"
               >
                 {{ 'General.DontHeading' | translate }}
               </h4>
@@ -377,7 +377,7 @@
         </div>
       </div>
       <div class="element-wrapper-container mt_8">
-        <h3 class="h5 emphasis sub-headings">
+        <h3 class="emphasis sub-headings">
           {{
             'Banner.DesignGuideLines.ProperButtonTypeInGroupLabel' | translate
           }}
@@ -392,7 +392,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-green"
+                class="do-dont-heading emphasis text-underline text-color-green"
               >
                 {{ 'General.DoHeading' | translate }}
               </h4>
@@ -410,7 +410,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-red"
+                class="do-dont-heading emphasis text-underline text-color-red"
               >
                 {{ 'General.DontHeading' | translate }}
               </h4>
@@ -424,7 +424,7 @@
         </div>
       </div>
       <div class="element-wrapper-container mt_8">
-        <h3 class="h5 emphasis sub-headings">
+        <h3 class="emphasis sub-headings">
           {{ 'Banner.DesignGuideLines.BannerCorrectDismissLabel' | translate }}
         </h3>
         <div class="row">
@@ -437,7 +437,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-green"
+                class="do-dont-heading emphasis text-underline text-color-green"
               >
                 {{ 'General.DoHeading' | translate }}
               </h4>
@@ -455,7 +455,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-red"
+                class="do-dont-heading emphasis text-underline text-color-red"
               >
                 {{ 'General.DontHeading' | translate }}
               </h4>
@@ -469,7 +469,7 @@
         </div>
       </div>
       <div class="element-wrapper-container">
-        <h3 class="h5 sub-headings">
+        <h3 class="sub-headings">
           {{ 'General.MaxMinWidthHeading' | translate }}
         </h3>
         <div>
@@ -505,7 +505,7 @@
           <div class="anatomy-content-container">
             <div class="counter-and-heading-container">
               <div class="round-purple-num-count">{{ i + 1 }}</div>
-              <h3 class="h5 round-purple-num-heading">
+              <h3 class="round-purple-num-heading">
                 <strong>{{ content.title | translate }}</strong>
               </h3>
             </div>
@@ -545,7 +545,7 @@
 
     <div class="wrapper-container">
       <div class="element-wrapper-container">
-        <h3 class="h5 emphasis sub-headings">
+        <h3 class="emphasis sub-headings">
           {{ 'Banner.ContentGuideLines.UseCorrectCaseHeading' | translate }}
         </h3>
         <div class="row">
@@ -558,7 +558,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-green"
+                class="do-dont-heading emphasis text-underline text-color-green"
               >
                 {{ 'General.DoHeading' | translate }}
               </h4>
@@ -580,7 +580,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-red"
+                class="do-dont-heading emphasis text-underline text-color-red"
               >
                 {{ 'General.DontHeading' | translate }}
               </h4>
@@ -596,7 +596,7 @@
       </div>
 
       <div class="element-wrapper-container">
-        <h3 class="h5 emphasis sub-headings">
+        <h3 class="emphasis sub-headings">
           {{ 'Banner.ContentGuideLines.EasyToReadTitleHeading' | translate }}
         </h3>
         <div class="row">
@@ -609,7 +609,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-green"
+                class="do-dont-heading emphasis text-underline text-color-green"
               >
                 {{ 'General.DoHeading' | translate }}
               </h4>
@@ -627,7 +627,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-red"
+                class="do-dont-heading emphasis text-underline text-color-red"
               >
                 {{ 'General.DontHeading' | translate }}
               </h4>
@@ -640,7 +640,7 @@
       </div>
 
       <div class="element-wrapper-container">
-        <h3 class="h5 emphasis sub-headings">
+        <h3 class="emphasis sub-headings">
           {{ 'Banner.ContentGuideLines.ProperPunctuationHeading' | translate }}
         </h3>
         <div class="row">
@@ -653,7 +653,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-green"
+                class="do-dont-heading emphasis text-underline text-color-green"
               >
                 {{ 'General.DoHeading' | translate }}
               </h4>
@@ -673,7 +673,7 @@
             />
             <div class="do-dont-desc">
               <h4
-                class="h5 do-dont-heading emphasis text-underline text-color-red"
+                class="do-dont-heading emphasis text-underline text-color-red"
               >
                 {{ 'General.DontHeading' | translate }}
               </h4>
@@ -696,7 +696,7 @@
     ></app-title-slug-url>
     <div class="row">
       <div class="col-12 col-md-8">
-        <h3 class="h5 sub-headings">
+        <h3 class="sub-headings">
           {{ 'General.FigmaDirectionsHeading' | translate }}
         </h3>
         <ol>
@@ -724,7 +724,7 @@
     ></app-title-slug-url>
     <div class="wrapper-container">
       <div class="element-wrapper-container">
-        <h3 class="h5 sub-headings">
+        <h3 class="sub-headings">
           {{ 'General.AccessibilityColourHeading' | translate }}
         </h3>
         <ul class="list-container">
@@ -736,7 +736,7 @@
         </ul>
       </div>
       <div class="element-wrapper-container">
-        <h3 class="h5 sub-headings">
+        <h3 class="sub-headings">
           {{ 'General.AccessibilityKeyboardHeading' | translate }}
         </h3>
         <p class="body3">


### PR DESCRIPTION
**Why are these changes introduced?**
* Related task #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/929249))


**What is this pull request doing?**
* Removes h5 class from h3 tags which was applying the wrong font weight

**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)

** File names and hierarchies are in keeping with our norms:
* Interfaces start with 'I' followed by a capital letter and camel case (IInterfaceExample) and are descriptive
* Subjects are suffixed with 'Subj' (ex: thisIsAnExampleSubj)
* Subscriptions are suffixed with 'Sub' (ex: thisIsAnExampleSub)
* Observables ere suffixed with 'Obs$' (ex: thisIsAnExampleObs$)
* Class and variable names are camel case
* Class names should start with a capital letter (i.e. ExampleClass)
* Variable names should start with a lower case letter (i.e thisIsAnExampleVariable)
* All caps and underscores are used for exported constants (THIS_IS_A_CONSTANT)
* Names are all spelled correctly
* ngOnInit and constructor is removed when not used
* ':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?

**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.