### PR TITLE
Radio error aria label fix

### DIFF
--- a/component-library/component-lib/src/lib/form-components/radio-input/radio-input.component.ts
+++ b/component-library/component-lib/src/lib/form-components/radio-input/radio-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, Input, OnInit } from '@angular/core';
+import { Component, forwardRef, Input, OnChanges, OnInit } from '@angular/core';
 import {
   AbstractControl,
   ControlValueAccessor,
@@ -55,7 +55,9 @@ export interface IRadioInputOption {
     }
   ]
 })
-export class RadioInputComponent implements OnInit, ControlValueAccessor {
+export class RadioInputComponent
+  implements OnInit, OnChanges, ControlValueAccessor
+{
   formGroupEmpty = new FormGroup({});
   touched = false;
   errorIds: IErrorIDs[] = [];
@@ -134,7 +136,8 @@ export class RadioInputComponent implements OnInit, ControlValueAccessor {
 
     //set config from individual options, if present
     if (this.id !== '') this.config.id = this.id;
-    if (this.formGroup !== this.formGroupEmpty) this.config.formGroup = this.formGroup;
+    if (this.formGroup !== this.formGroupEmpty)
+      this.config.formGroup = this.formGroup;
     if (this.size) this.config.size = this.size;
     if (this.label) this.config.label = this.label;
     if (this.desc) this.config.desc = this.desc;
@@ -154,6 +157,10 @@ export class RadioInputComponent implements OnInit, ControlValueAccessor {
         this.config.errorMessages
       );
     }
+
+    this.formControl?.statusChanges.subscribe((status) => {
+      this.getAriaErrorText();
+    });
   }
 
   ngOnChanges() {


### PR DESCRIPTION
Why are these changes introduced?
- Related story [920324](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/920324)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-radio-error/en/mike-en)

What is this pull request doing?

- Fix radio error message does not show up in aria label

Reviewer checklist:

1. Go to [qa page](https://d1whfh0luwluq8.cloudfront.net/qa-radio-error/en/mike-en) then click radio component
2. Toggle radio button with 1- 2 errors
3. Verify error message show up in aria label