### PR TITLE
Bug/language toggle style

### DIFF
--- a/component-library/component-lib/src/lib/header-footer/language-switch/language-switch.component.html
+++ b/component-library/component-lib/src/lib/header-footer/language-switch/language-switch.component.html
@@ -1,5 +1,4 @@
 <a
-  role="link"
   [id]="id"
   (click)="switch()"
   id="language-toggle"

--- a/component-library/component-lib/src/lib/header-footer/language-switch/language-switch.component.html
+++ b/component-library/component-lib/src/lib/header-footer/language-switch/language-switch.component.html
@@ -1,8 +1,7 @@
-<button
-  category="link"
+<a
   role="link"
   [id]="id"
   (click)="switch()"
   id="language-toggle"
   [innerHTML]="text"
-></button>
+></a>

--- a/core-library/component-styling/language-switch/_language-switch.scss
+++ b/core-library/component-styling/language-switch/_language-switch.scss
@@ -16,9 +16,18 @@
 }
 
 @mixin layout {
-  button {
+  a {
+    padding: 0;
     margin-bottom: 28px;
     margin-top: 24px;
     margin-left: 20px;
+    cursor: pointer;
+    text-decoration: underline;
+    @include typography.fontSet(body, 2, regular);
+    color: var(--link-text);;
+      &:visited {
+        color: var(--link-text-visited);
+      }
+    
   }
 }

--- a/core-library/component-styling/language-switch/_language-switch.scss
+++ b/core-library/component-styling/language-switch/_language-switch.scss
@@ -24,10 +24,10 @@
     cursor: pointer;
     text-decoration: underline;
     @include typography.fontSet(body, 2, regular);
-    color: var(--link-text);;
-      &:visited {
-        color: var(--link-text-visited);
-      }
+    color: var(--link-text);
     
+    &:visited {
+        color: var(--link-text-visited);
+      } 
   }
 }


### PR DESCRIPTION
**Why are these changes introduced?**
* Related story #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/909658))

**What is this pull request doing?**
* Removes button component from Language Toggle Switcher
* Adds anchor tag with styling to match classic link style per confirmation with design
* Note: route navigation on language toggle is a separate defect and no href has been added to the <a> tag since the routing is handled by the shell component

**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)

** File names and hierarchies are in keeping with our norms:
* Interfaces start with 'I' followed by a capital letter and camel case (IInterfaceExample) and are descriptive
* Subjects are suffixed with 'Subj' (ex: thisIsAnExampleSubj)
* Subscriptions are suffixed with 'Sub' (ex: thisIsAnExampleSub)
* Observables ere suffixed with 'Obs$' (ex: thisIsAnExampleObs$)
* Class and variable names are camel case
* Class names should start with a capital letter (i.e. ExampleClass)
* Variable names should start with a lower case letter (i.e thisIsAnExampleVariable)
* All caps and underscores are used for exported constants (THIS_IS_A_CONSTANT)
* Names are all spelled correctly
* ngOnInit and constructor is removed when not used
* ':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?

**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.