### PR TITLE
Qa/button doc fix: Images are not correctly sized for various devices (Desktop, Mobile, Tablet).

### DIFF
--- a/component-library/component-lib/src/shared/constants/jl-components.constants.ts
+++ b/component-library/component-lib/src/shared/constants/jl-components.constants.ts
@@ -23,3 +23,8 @@ export enum DSOrientations {
   horizontal = 'horizontal',
   vertical = 'vertical'
 }
+
+export enum DSViewPortSize {
+  mobile = 768, // Anything less than 768px is mobile
+  tablet = 992 // Anything between 768px & 992px is tablet
+}

--- a/component-library/src/app/components/component-preview/component-preview.component.html
+++ b/component-library/src/app/components/component-preview/component-preview.component.html
@@ -1,5 +1,5 @@
 <div
-  class="preview-wrapper background-{{ backgroundColor }}"
+  class="preview-wrapper background-{{ backgroundColor }} {{ positionClass }}"
   [style.min-width]="minWidth > 0 ? minWidth + 'px' : 0"
 >
   <ng-content></ng-content>

--- a/component-library/src/app/components/component-preview/component-preview.component.html
+++ b/component-library/src/app/components/component-preview/component-preview.component.html
@@ -1,6 +1,6 @@
 <div
   class="preview-wrapper background-{{ backgroundColor }} {{ positionClass }}"
-  [style.min-width]="minWidth > 0 ? minWidth + 'px' : 0"
+  [style.min-width]="minWidth > 0 && !mobile ? minWidth + 'px' : 0"
 >
   <ng-content></ng-content>
   <ircc-cl-lib-button

--- a/component-library/src/app/components/component-preview/component-preview.component.html
+++ b/component-library/src/app/components/component-preview/component-preview.component.html
@@ -1,4 +1,7 @@
-<div class="preview-wrapper background-{{ backgroundColor }}">
+<div
+  class="preview-wrapper background-{{ backgroundColor }}"
+  [style.min-width]="minWidth > 0 ? minWidth + 'px' : 0"
+>
   <ng-content></ng-content>
   <ircc-cl-lib-button
     *ngIf="copyText"

--- a/component-library/src/app/components/component-preview/component-preview.component.scss
+++ b/component-library/src/app/components/component-preview/component-preview.component.scss
@@ -22,7 +22,8 @@ $selectors: "app-component-preview";
 
   .preview-wrapper {
     box-sizing: border-box;
-    padding: 0 64px;
+    padding-top: 60px;
+    padding-bottom: 44px;
     height: 100%;
     display: inline-flex;
     align-items: center;
@@ -32,6 +33,11 @@ $selectors: "app-component-preview";
 
     @include grid.in-phone-layout {
       width: 100%;
+    }
+
+    @include grid.up-phone-layout {
+      padding-left: 64px;
+      padding-right: 64px;
     }
 
     ircc-cl-lib-button.copy {

--- a/component-library/src/app/components/component-preview/component-preview.component.scss
+++ b/component-library/src/app/components/component-preview/component-preview.component.scss
@@ -30,7 +30,7 @@ $selectors: "app-component-preview";
     flex-direction: column;
     min-height: 170px;
 
-    @include grid.un-tablet-layout {
+    @include grid.in-phone-layout {
       width: 100%;
     }
 

--- a/component-library/src/app/components/component-preview/component-preview.component.scss
+++ b/component-library/src/app/components/component-preview/component-preview.component.scss
@@ -22,7 +22,7 @@ $selectors: "app-component-preview";
 
   .preview-wrapper {
     box-sizing: border-box;
-    padding: 59px 65px 44px 65px;
+    padding: 0 64px;
     height: 100%;
     display: inline-flex;
     align-items: center;

--- a/component-library/src/app/components/component-preview/component-preview.component.scss
+++ b/component-library/src/app/components/component-preview/component-preview.component.scss
@@ -31,6 +31,19 @@ $selectors: "app-component-preview";
     flex-direction: column;
     min-height: 170px;
 
+    &.multi-first {
+      padding-bottom: 16px;
+    }
+
+    &.multi-middle {
+      padding-top: 0;
+      padding-bottom: 16px;
+    }
+
+    &.multi-last {
+      padding-top: 0;
+    }
+
     @include grid.in-phone-layout {
       width: 100%;
     }

--- a/component-library/src/app/components/component-preview/component-preview.component.ts
+++ b/component-library/src/app/components/component-preview/component-preview.component.ts
@@ -15,9 +15,17 @@ export class ComponentPreviewComponent implements OnInit {
   @Input() copyStyle?: string;
   @Input() backgroundColor?: keyof typeof BackgroundColor;
   @Input() minWidth: number = 0;
+  @Input() multiConfig?: {
+    multi: boolean;
+    position: 'first' | 'middle' | 'last';
+  };
+
+  positionClass?: string;
 
   ngOnInit() {
     if (!this.backgroundColor) this.backgroundColor = BackgroundColor.gray;
+    if (this.multiConfig && this.multiConfig.multi)
+      this.positionClass = 'multi-' + this.multiConfig.position;
 
     this.backgroundColor === BackgroundColor.white
       ? BackgroundColor.white

--- a/component-library/src/app/components/component-preview/component-preview.component.ts
+++ b/component-library/src/app/components/component-preview/component-preview.component.ts
@@ -14,6 +14,7 @@ export class ComponentPreviewComponent implements OnInit {
   @Input() copyText?: string;
   @Input() copyStyle?: string;
   @Input() backgroundColor?: keyof typeof BackgroundColor;
+  @Input() minWidth: number = 0;
 
   ngOnInit() {
     if (!this.backgroundColor) this.backgroundColor = BackgroundColor.gray;

--- a/component-library/src/app/components/component-preview/component-preview.component.ts
+++ b/component-library/src/app/components/component-preview/component-preview.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, HostListener, Input, OnInit } from '@angular/core';
+import { DSViewPortSize } from 'ircc-ds-angular-component-library';
 
 export enum BackgroundColor {
   white = 'white',
@@ -21,6 +22,7 @@ export class ComponentPreviewComponent implements OnInit {
   };
 
   positionClass?: string;
+  mobile: boolean = false;
 
   ngOnInit() {
     if (!this.backgroundColor) this.backgroundColor = BackgroundColor.gray;
@@ -30,5 +32,11 @@ export class ComponentPreviewComponent implements OnInit {
     this.backgroundColor === BackgroundColor.white
       ? BackgroundColor.white
       : BackgroundColor.gray;
+    this.mobile = window.innerWidth < DSViewPortSize.mobile;
+  }
+
+  @HostListener('window:resize', ['$event'])
+  onResize() {
+    this.mobile = window.innerWidth < DSViewPortSize.mobile;
   }
 }

--- a/component-library/src/app/pages/button-documentation/button-documentation.component.html
+++ b/component-library/src/app/pages/button-documentation/button-documentation.component.html
@@ -70,6 +70,7 @@
           copyText="<button category='plain'>{{
             'Buttons.PlainBtnText' | translate
           }}</button>"
+          [minWidth]="338"
         >
           <ircc-cl-lib-button [config]="buttonTypeConfigs['plain']">
             {{ 'Buttons.PlainBtnText' | translate }}
@@ -79,6 +80,7 @@
           copyText="<button category='plain' color='critical'>{{
             'Buttons.PlainCritBtnText' | translate
           }}</button>"
+          [minWidth]="338"
         >
           <ircc-cl-lib-button [config]="buttonTypeConfigs['plain_critical']">
             {{ 'Buttons.PlainCritBtnText' | translate }}

--- a/component-library/src/app/pages/button-documentation/button-documentation.component.html
+++ b/component-library/src/app/pages/button-documentation/button-documentation.component.html
@@ -71,6 +71,7 @@
             'Buttons.PlainBtnText' | translate
           }}</button>"
           [minWidth]="338"
+          [multiConfig]="{ multi: true, position: 'first' }"
         >
           <ircc-cl-lib-button [config]="buttonTypeConfigs['plain']">
             {{ 'Buttons.PlainBtnText' | translate }}
@@ -81,6 +82,7 @@
             'Buttons.PlainCritBtnText' | translate
           }}</button>"
           [minWidth]="338"
+          [multiConfig]="{ multi: true, position: 'last' }"
         >
           <ircc-cl-lib-button [config]="buttonTypeConfigs['plain_critical']">
             {{ 'Buttons.PlainCritBtnText' | translate }}

--- a/component-library/src/app/pages/button-documentation/button-documentation.component.ts
+++ b/component-library/src/app/pages/button-documentation/button-documentation.component.ts
@@ -7,6 +7,7 @@ import {
 } from '@app/components/title-slug-url/title-slug-url.component';
 import { IButtonConfig } from 'ircc-ds-angular-component-library';
 import { docPageheadingConfig } from '@app/share/documentation-page-headings';
+import { DSViewPortSize } from 'ircc-ds-angular-component-library';
 
 @Component({
   selector: 'app-button-documentation',
@@ -67,11 +68,11 @@ export class ButtonDocumentationComponent implements OnInit {
 
   ngOnInit() {
     this.lang.setAltLangLink(this.altLangLink);
-    this.mobile = window.innerWidth <= 768;
+    this.mobile = window.innerWidth < DSViewPortSize.mobile;
   }
 
   @HostListener('window:resize', ['$event'])
   onResize() {
-    this.mobile = window.innerWidth <= 768;
+    this.mobile = window.innerWidth < DSViewPortSize.mobile;
   }
 }


### PR DESCRIPTION
Why are these changes introduced?
- Related story [929702](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/929702)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-button-doc-fix/en/buttons)

What is this pull request doing?

- Change component preview mobile cut point
- Change button page mobile img cut point to 767px

Reviewer checklist:

1. Go to [qa page](https://d1whfh0luwluq8.cloudfront.net/qa-button-doc-fix/en/buttons)
2. Compare with [design](https://www.figma.com/file/TPwx1HcbXRCZeIDePI4Y4N/Documentation-Site?type=design&node-id=590-20111&mode=design&t=pPi1WQoawK9s1G1h-4)