### PR TITLE
Indicator: Should not be able to tab in to the Indicator component

### DIFF
--- a/component-library/component-lib/src/lib/shared/indicator/indicator.component.ts
+++ b/component-library/component-lib/src/lib/shared/indicator/indicator.component.ts
@@ -68,7 +68,7 @@ export class IndicatorComponent implements OnInit, AfterViewInit, OnChanges {
     type: 'text',
     category: IndicatorTreatment.weak,
     purpose: IndicatorPurpose.status,
-    tabIndex: 0
+    tabIndex: -1
   };
 
   @Input() size?: keyof typeof DSSizes;
@@ -96,6 +96,7 @@ export class IndicatorComponent implements OnInit, AfterViewInit, OnChanges {
     if (this.status) this.config.status = this.status;
     if (this.palette) this.config.palette = this.palette;
     if (this.ariaLabel) this.config.ariaLabel = this.ariaLabel;
+    if (!this.tabIndex) this.config.tabIndex = -1;
 
     this.checkLabelRounded();
     this.checkNumber();


### PR DESCRIPTION
Why are these changes introduced?
- Related task [923994](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/923994)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-indicator-no-tab/en/michael-en)

What is this pull request doing?

- Disable tab for indicator component

Reviewer checklist:

1. Go to [qa page](https://d1whfh0luwluq8.cloudfront.net/qa-indicator-no-tab/en/michael-en)
2. Verify indicator cannot be tabbed into