### PR TITLE
reduce vh to 90 for side nav to avoid collapse over the footer

### DIFF
--- a/component-library/src/app/components/side-nav/side-nav.component.scss
+++ b/component-library/src/app/components/side-nav/side-nav.component.scss
@@ -41,7 +41,7 @@ $footer-height: 310px;
       @include grid.up-laptop-layout {
         position: fixed;
         top: 0;
-        height: 100vh;
+        height: 90vh;
         overflow-y: auto;
       }
     }


### PR DESCRIPTION
hot fix for the right side nav height collapsing on the footer.