### PR TITLE
Breadcrumb must be imbedded in a <nav> tag

### DIFF
--- a/component-library/component-lib/src/lib/shared/breadcrumb/breadcrumb.component.html
+++ b/component-library/component-lib/src/lib/shared/breadcrumb/breadcrumb.component.html
@@ -1,4 +1,4 @@
-<div
+<nav
   class="{{ config.size }}"
   (domChange)="createOverflows()"
   #breadcrumb_div
@@ -67,4 +67,4 @@
       </p>
     </ng-container>
   </ng-container>
-</div>
+</nav>

--- a/component-library/component-lib/src/lib/shared/breadcrumb/breadcrumb.component.html
+++ b/component-library/component-lib/src/lib/shared/breadcrumb/breadcrumb.component.html
@@ -1,6 +1,7 @@
 <nav
   class="{{ config.size }}"
   (domChange)="createOverflows()"
+  [attr.aria-label]="'Breadcrumb.Title' | translate"
   #breadcrumb_div
 >
   <ng-container

--- a/component-library/component-lib/src/lib/shared/breadcrumb/breadcrumb.component.ts
+++ b/component-library/component-lib/src/lib/shared/breadcrumb/breadcrumb.component.ts
@@ -66,7 +66,7 @@ export class BreadcrumbComponent implements OnInit, OnChanges, AfterViewInit {
   displayOverflow = false;
   private maxHeight: number = 0; // Max height of element in px
   @ViewChild('breadcrumb_div', { static: false })
-  divRef?: ElementRef<HTMLDivElement>;
+  divRef?: ElementRef<HTMLElement>;
   @ViewChild('breadcrumb_child', { static: false })
   childRef?: ElementRef<HTMLParagraphElement>;
   isChildOverflow: boolean = false;

--- a/component-library/component-lib/src/lib/shared/breadcrumb/link/link.component.html
+++ b/component-library/component-lib/src/lib/shared/breadcrumb/link/link.component.html
@@ -1,5 +1,6 @@
 <ng-container *ngIf="config.href">
   <a
+    class="breadcrumb-anchor"
     [href]="config.href"
     tabindex="-1"
     >{{ config.text | translate }}
@@ -7,6 +8,7 @@
 </ng-container>
 <ng-container *ngIf="config.routerLink">
   <a
+    class="breadcrumb-anchor"
     type="button"
     tabindex="-1"
     [routerLink]="config.routerLink"

--- a/component-library/src/assets/locales/en.json
+++ b/component-library/src/assets/locales/en.json
@@ -779,6 +779,9 @@
 			"CTA3Label": "CTA 3 (if CTA 1 is set to true)"
 		}
 	},
+	"Breadcrumb": {
+		"Title": "Breadcrumb"
+	},
 	"General": {
 		"InteractiveDemo": "Interactive Demo",
 		"InteractiveDemoDesc1": "Try our",

--- a/component-library/src/assets/locales/fr.json
+++ b/component-library/src/assets/locales/fr.json
@@ -779,6 +779,9 @@
 			"CTA3Label": "CTA 3 (si CTA 1 est défini sur true)"
 		}
 	},
+	"Breadcrumb": {
+		"Title": "Miette de pain"
+	},
 	"General": {
 		"InteractiveDemo": "Démo interactive",
 		"InteractiveDemoDesc1": "Essayez notre",

--- a/core-library/component-styling/breadcrumb/_breadcrumb.scss
+++ b/core-library/component-styling/breadcrumb/_breadcrumb.scss
@@ -134,7 +134,8 @@
 
     a.breadcrumb-anchor {
       text-decoration: none;
-      padding: 0;
+      border-radius: 4px;
+      padding: 2px 4px;
       color: var(--link-text);
 
       &:focus {

--- a/core-library/component-styling/breadcrumb/_breadcrumb.scss
+++ b/core-library/component-styling/breadcrumb/_breadcrumb.scss
@@ -24,7 +24,7 @@
 // For size small overwrite
 @mixin size-sm {
   ircc-cl-lib-breadcrumb-link {
-    a,
+    a.breadcrumb-anchor,
     ircc-cl-lib-button .text {
       @include typography.fontSet(body, 3, regular);
     }
@@ -62,7 +62,7 @@
   ircc-cl-lib-breadcrumb-link {
     margin-right: 4px;
 
-    a,
+    a.breadcrumb-anchor,
     ircc-cl-lib-button .text {
       @include typography.fontSet(body, 2, regular);
     }
@@ -104,7 +104,7 @@
   padding: 6px 0;
   position: relative;
 
-  > div {
+  > nav {
     display: flex;
     flex-wrap: nowrap;
     align-items: center;
@@ -132,9 +132,10 @@
       }
     }
 
-    a {
+    a.breadcrumb-anchor {
       text-decoration: none;
       padding: 0;
+      color: var(--link-text);
 
       &:focus {
         outline: none;
@@ -143,6 +144,11 @@
       &:hover,
       &:active {
         background: none;
+      }
+
+      &:hover {
+        color: var(--link-text-hover);
+        background-color: var(--generic-hover);
       }
     }
 
@@ -225,6 +231,10 @@
     ircc-cl-lib-breadcrumb-link {
       &:hover {
         background-color: var(--generic-active);
+
+        a.breadcrumb-anchor {
+          background-color: transparent;
+        }
       }
 
       a {


### PR DESCRIPTION
Why are these changes introduced?
- Related bug [933015](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/933015)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-breadcrumb-nav/en/michael-en)

What is this pull request doing?

- Wrap breadcrumb in nav tag
- Add aria label to breadcrumb

Reviewer checklist:

1. Go to [qa page](https://d1whfh0luwluq8.cloudfront.net/qa-breadcrumb-nav/en/michael-en) and click Breadcrumb
2. Verify breadcrumb styling has no change