### PR TITLE
Input field in the Basic tab keeps the password input value.

### DIFF
--- a/component-library/component-lib/src/lib/form-components/input/input.component.ts
+++ b/component-library/component-lib/src/lib/form-components/input/input.component.ts
@@ -297,6 +297,9 @@ export class InputComponent
     } else {
       this.errorIds = [];
     }
+
+    if (this.config.type === InputTypes.text)
+      this.typeControl = InputTypes.text;
   }
 
   /**

--- a/component-library/component-lib/src/lib/form-components/input/input.component.ts
+++ b/component-library/component-lib/src/lib/form-components/input/input.component.ts
@@ -300,6 +300,10 @@ export class InputComponent
 
     if (this.config.type === InputTypes.text)
       this.typeControl = InputTypes.text;
+
+    this.showPassword =
+      this.config.type === InputTypes.password &&
+      this.typeControl === InputTypes.text;
   }
 
   /**


### PR DESCRIPTION
Why are these changes introduced?
- Related bug [938590](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/938590)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-input-demo-bug/en/input-documentation)

What is this pull request doing?

- Fix issue input field in the Basic tab keeps the password input value.

Reviewer checklist:

1. Go to [qa page](https://d1whfh0luwluq8.cloudfront.net/qa-input-demo-bug/en/input-documentation)
2. Choose password type
3. Put random value at input field, then click eye icon to hide it.
4. Flip back to Basic, verify input show up as normal text.