### PR TITLE
Component preview enhancement

### DIFF
--- a/component-library/src/app/components/component-preview/component-preview.component.scss
+++ b/component-library/src/app/components/component-preview/component-preview.component.scss
@@ -54,7 +54,7 @@ $selectors: "app-component-preview";
     }
 
     ircc-cl-lib-button.copy {
-      margin-top: 10px;
+      margin-top: 12px;
     }
   }
 


### PR DESCRIPTION
Why are these changes introduced?
- Related story [934385](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/934385)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-component-preview/en/buttons)

What is this pull request doing?

Desktop & tablet:

- Container is fluid based on component
- Left and right padding of 64px
- Top padding of 60px
- Bottom padding of 44px
- Margin of 12px between component and "copy style" button

Mobile:

- Width fills mobile container
- Component is center-aligned
- Top padding of 60px
- Bottom padding of 44px

Reviewer checklist:

1. Go to [qa page](https://d1whfh0luwluq8.cloudfront.net/qa-component-preview/en/buttons)
2. Verify component preview is same as [design spec](https://www.figma.com/file/TPwx1HcbXRCZeIDePI4Y4N/Documentation-Site?type=design&node-id=6640-193516&mode=design&t=Al1sG1sPBhOkXe5t-4)