### PR TITLE
update radio component control values disabled state handling

### DIFF
--- a/component-library/component-lib/src/lib/form-components/radio-input/radio-input.component.html
+++ b/component-library/component-lib/src/lib/form-components/radio-input/radio-input.component.html
@@ -19,7 +19,7 @@
         id="{{ config.id + index }}"
         (click)="standAloneFunctions.wasTouched(config.formGroup, config.id)"
         [formControlName]="config.id ? config.id : 'formControl'"
-        [attr.disabled]="getDisabled(index)"
+        [disabled]="currentStatus !== 'DISABLED'"
         [ngClass]="option?.sizeOverride ? option?.sizeOverride : config.size"
         [attr.aria-invalid]="formControl?.invalid"
         [attr.aria-live]="'off'"
@@ -59,7 +59,7 @@
     </div>
   </div>
   <div aria-live="polite">
-    <ng-container *ngIf="formControl?.touched && formControl?.invalid">
+    <ng-container *ngIf="currentStatus === 'INVALID'">
       <span class="sr-only">{{
         errorStubText + ': ' + (config.label || '' | translate) + ': '
       }}</span>

--- a/component-library/component-lib/src/lib/form-components/radio-input/radio-input.component.ts
+++ b/component-library/component-lib/src/lib/form-components/radio-input/radio-input.component.ts
@@ -250,20 +250,4 @@ export class RadioInputComponent
       this.formGroup.get(this.config.id)?.enable();
     }
   }
-  /**
-   * used to disable individual fields (from the config under 'options')
-   * @param index of the option field to be disabled
-   * @returns null if value is undefined, empty string otherwise. This works with [attr.disabled].
-   */
-  // getDisabled(index: number) {
-  //   if (this.config.options) {
-  //     if (
-  //       this.config.options[index].disabled === undefined &&
-  //       !this.config.disabled
-  //     ) {
-  //       return null;
-  //     }
-  //   }
-  //   return '';
-  // }
 }

--- a/component-library/src/app/components/interactive-demo/interactive-demo.component.ts
+++ b/component-library/src/app/components/interactive-demo/interactive-demo.component.ts
@@ -3,7 +3,7 @@ import {
   EventEmitter,
   HostListener,
   Input,
-  OnInit,
+  OnInit
 } from '@angular/core';
 import { IIconButtonIconConfig } from 'ircc-ds-angular-component-library';
 import {

--- a/component-library/src/app/pages/autocomplete-documentation/autocomplete-documentation.component.ts
+++ b/component-library/src/app/pages/autocomplete-documentation/autocomplete-documentation.component.ts
@@ -196,11 +196,11 @@ export class AutocompleteDocumentationComponent
   ];
 
   bannerConfig: IBannerConfig = {
-    id: "banner-disabled-desc",
-    type: "info",
-    size: "small",
-    title:'General.EnabledBannerTitle',
-    content: "General.EnabledBannerContent",
+    id: 'banner-disabled-desc',
+    type: 'info',
+    size: 'small',
+    title: 'General.EnabledBannerTitle',
+    content: 'General.EnabledBannerContent',
     rounded: true
   };
 
@@ -243,7 +243,7 @@ export class AutocompleteDocumentationComponent
           "import { IAutocompleteComponent } from 'ircc-ds-angular-component-library';\n//...\n" +
           `config: IAutocompleteComponent = ${stringify(
             this.autocompleteCodeView
-          )}`
+          )}`;
       }
     });
 
@@ -257,12 +257,12 @@ export class AutocompleteDocumentationComponent
       ?.valueChanges.subscribe((change) => {
         if (change) {
           this.config.formGroup.get(this.config.id)?.disable(change);
-          this.bannerConfig.title='General.DisabledBannerTitle'
-          this.bannerConfig.content="General.DisabledBannerContent"
+          this.bannerConfig.title = 'General.DisabledBannerTitle';
+          this.bannerConfig.content = 'General.DisabledBannerContent';
         } else {
           this.config.formGroup.get(this.config.id)?.enable(change);
-          this.bannerConfig.title='General.EnabledBannerTitle'
-          this.bannerConfig.content="General.EnabledBannerContent"
+          this.bannerConfig.title = 'General.EnabledBannerTitle';
+          this.bannerConfig.content = 'General.EnabledBannerContent';
         }
       });
 

--- a/component-library/src/app/pages/button-documentation/button-doc-code.component.ts
+++ b/component-library/src/app/pages/button-documentation/button-doc-code.component.ts
@@ -190,11 +190,11 @@ export class ButtonDocCodeComponent implements OnInit, TranslatedPageComponent {
   };
 
   bannerConfig: IBannerConfig = {
-    id: "banner-disabled-desc",
-    type: "info",
-    size: "small",
-    title:'General.EnabledBannerTitle',
-    content: "General.EnabledBannerContent",
+    id: 'banner-disabled-desc',
+    type: 'info',
+    size: 'small',
+    title: 'General.EnabledBannerTitle',
+    content: 'General.EnabledBannerContent',
     rounded: true
   };
 
@@ -345,16 +345,17 @@ export class ButtonDocCodeComponent implements OnInit, TranslatedPageComponent {
       }
     });
 
-    this.formButton.get(this.checkboxes[0].id)
-    ?.valueChanges.subscribe((change) => {
-      if (change) {
-        this.bannerConfig.title='General.DisabledBannerTitle'
-        this.bannerConfig.content="General.DisabledBannerContent"
-      } else {
-        this.bannerConfig.title='General.EnabledBannerTitle'
-        this.bannerConfig.content="General.EnabledBannerContent"
-      }
-    });
+    this.formButton
+      .get(this.checkboxes[0].id)
+      ?.valueChanges.subscribe((change) => {
+        if (change) {
+          this.bannerConfig.title = 'General.DisabledBannerTitle';
+          this.bannerConfig.content = 'General.DisabledBannerContent';
+        } else {
+          this.bannerConfig.title = 'General.EnabledBannerTitle';
+          this.bannerConfig.content = 'General.EnabledBannerContent';
+        }
+      });
 
     this.toggles.forEach((toggle) => {
       if (toggle.options) {

--- a/component-library/src/app/pages/date-picker-documentation/date-picker-doc-code.component.ts
+++ b/component-library/src/app/pages/date-picker-documentation/date-picker-doc-code.component.ts
@@ -56,15 +56,26 @@ export class DatePickerDocCodeComponent
     ...this.datePickerConfig,
     id: 'datepicker_single',
     required: true,
-    errorMessages: [{ key: 'required', errorLOV: this.translate.instant('ERROR.singleError') }]
+    errorMessages: [
+      { key: 'required', errorLOV: this.translate.instant('ERROR.singleError') }
+    ]
   };
   datePickerConfigMulti: IDatePickerConfig = {
     ...this.datePickerConfig,
     id: 'datepicker_multi',
     errorMessages: [
-      { key: 'required', errorLOV: this.translate.instant('ERROR.singleError') },
-      { key: 'required', errorLOV: this.translate.instant('ERROR.additionalError') },
-      { key: 'required', errorLOV: this.translate.instant('ERROR.additionalError') }
+      {
+        key: 'required',
+        errorLOV: this.translate.instant('ERROR.singleError')
+      },
+      {
+        key: 'required',
+        errorLOV: this.translate.instant('ERROR.additionalError')
+      },
+      {
+        key: 'required',
+        errorLOV: this.translate.instant('ERROR.additionalError')
+      }
     ]
   };
 
@@ -197,11 +208,11 @@ export class DatePickerDocCodeComponent
   ];
 
   bannerConfig: IBannerConfig = {
-    id: "banner-disabled-desc",
-    type: "info",
-    size: "small",
-    title:'General.EnabledBannerTitle',
-    content: "General.EnabledBannerContent",
+    id: 'banner-disabled-desc',
+    type: 'info',
+    size: 'small',
+    title: 'General.EnabledBannerTitle',
+    content: 'General.EnabledBannerContent',
     rounded: true
   };
 
@@ -321,16 +332,17 @@ export class DatePickerDocCodeComponent
       this.formDatePicker.addControl(checkbox.id, new FormControl());
     });
 
-    this.formDatePicker.get(this.checkboxes[0].id)
-    ?.valueChanges.subscribe((change) => {
-      if (change) {
-        this.bannerConfig.title='General.DisabledBannerTitle'
-        this.bannerConfig.content="General.DisabledBannerContent"
-      } else {
-        this.bannerConfig.title='General.EnabledBannerTitle'
-        this.bannerConfig.content="General.EnabledBannerContent"
-      }
-    });
+    this.formDatePicker
+      .get(this.checkboxes[0].id)
+      ?.valueChanges.subscribe((change) => {
+        if (change) {
+          this.bannerConfig.title = 'General.DisabledBannerTitle';
+          this.bannerConfig.content = 'General.DisabledBannerContent';
+        } else {
+          this.bannerConfig.title = 'General.EnabledBannerTitle';
+          this.bannerConfig.content = 'General.EnabledBannerContent';
+        }
+      });
 
     this.formDatePicker.patchValue({
       size: 'Small',
@@ -552,7 +564,7 @@ export class DatePickerDocCodeComponent
         "import { FormGroup } from '@angular/forms';\n\n" +
         `datePickerConfig: IDatePickerConfig = ${stringify(
           this.datePickerConfigCodeView
-      )}`;
+        )}`;
     }
   }
 }

--- a/component-library/src/app/pages/icon-button-documentation/icon-button-doc-code.component.ts
+++ b/component-library/src/app/pages/icon-button-documentation/icon-button-doc-code.component.ts
@@ -95,11 +95,11 @@ export class IconButtonDocCodeComponent
   };
 
   bannerConfig: IBannerConfig = {
-    id: "banner-disabled-desc",
-    type: "info",
-    size: "small",
-    title:'General.EnabledBannerTitle',
-    content: "General.EnabledBannerContent",
+    id: 'banner-disabled-desc',
+    type: 'info',
+    size: 'small',
+    title: 'General.EnabledBannerTitle',
+    content: 'General.EnabledBannerContent',
     rounded: true
   };
 
@@ -201,16 +201,17 @@ export class IconButtonDocCodeComponent
       }
     });
 
-    this.formIconBtn.get(this.checkboxes[0].id)
-    ?.valueChanges.subscribe((change) => {
-      if (change) {
-        this.bannerConfig.title='General.DisabledBannerTitle'
-        this.bannerConfig.content="General.DisabledBannerContent"
-      } else {
-        this.bannerConfig.title='General.EnabledBannerTitle'
-        this.bannerConfig.content="General.EnabledBannerContent"
-      }
-    });
+    this.formIconBtn
+      .get(this.checkboxes[0].id)
+      ?.valueChanges.subscribe((change) => {
+        if (change) {
+          this.bannerConfig.title = 'General.DisabledBannerTitle';
+          this.bannerConfig.content = 'General.DisabledBannerContent';
+        } else {
+          this.bannerConfig.title = 'General.EnabledBannerTitle';
+          this.bannerConfig.content = 'General.EnabledBannerContent';
+        }
+      });
 
     this.toggles.forEach((toggle) => {
       if (toggle.options && toggle.options[1].text) {

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -33,7 +33,10 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
   formInput = new FormGroup({});
   state: boolean = false;
 
-  constructor(private lang: LangSwitchService, private translate: TranslateService) {}
+  constructor(
+    private lang: LangSwitchService,
+    private translate: TranslateService
+  ) {}
 
   inputConfig: IInputComponentConfig = {
     id: 'input',
@@ -50,7 +53,9 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     ...this.inputConfig,
     id: 'input_single',
     required: true,
-    errorMessages: [{ key: 'required', errorLOV: this.translate.instant('ERROR.singleError') }]
+    errorMessages: [
+      { key: 'required', errorLOV: this.translate.instant('ERROR.singleError') }
+    ]
   };
 
   inputConfigMulti: IInputComponentConfig = {
@@ -58,8 +63,14 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     id: 'input_multi',
     errorMessages: [
       { key: 'email', errorLOV: this.translate.instant('ERROR.singleError') },
-      { key: 'email', errorLOV: this.translate.instant('ERROR.additionalError') },
-      { key: 'maxlength', errorLOV: this.translate.instant('ERROR.additionalError') }
+      {
+        key: 'email',
+        errorLOV: this.translate.instant('ERROR.additionalError')
+      },
+      {
+        key: 'maxlength',
+        errorLOV: this.translate.instant('ERROR.additionalError')
+      }
     ]
   };
 
@@ -190,11 +201,11 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
   };
 
   bannerConfig: IBannerConfig = {
-    id: "banner-disabled-desc",
-    type: "info",
-    size: "small",
-    title:'General.EnabledBannerTitle',
-    content: "General.EnabledBannerContent",
+    id: 'banner-disabled-desc',
+    type: 'info',
+    size: 'small',
+    title: 'General.EnabledBannerTitle',
+    content: 'General.EnabledBannerContent',
     rounded: true
   };
 
@@ -286,16 +297,17 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
       this.formInput.addControl(checkbox.id, new FormControl());
     });
 
-    this.formInput.get(this.checkboxes[0].id)
-    ?.valueChanges.subscribe((change) => {
-      if (change) {
-        this.bannerConfig.title='General.DisabledBannerTitle'
-        this.bannerConfig.content="General.DisabledBannerContent"
-      } else {
-        this.bannerConfig.title='General.EnabledBannerTitle'
-        this.bannerConfig.content="General.EnabledBannerContent"
-      }
-    });
+    this.formInput
+      .get(this.checkboxes[0].id)
+      ?.valueChanges.subscribe((change) => {
+        if (change) {
+          this.bannerConfig.title = 'General.DisabledBannerTitle';
+          this.bannerConfig.content = 'General.DisabledBannerContent';
+        } else {
+          this.bannerConfig.title = 'General.EnabledBannerTitle';
+          this.bannerConfig.content = 'General.EnabledBannerContent';
+        }
+      });
 
     this.formInput.patchValue({
       size: 'Small',
@@ -461,7 +473,7 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
         "import { FormGroup } from '@angular/forms';\n\n" +
         `inputConfig: IInputComponentConfig = ${stringify(
           this.inputConfigCodeView
-      )}`;
+        )}`;
     }
   }
 }

--- a/component-library/src/app/pages/request-form/request-form.component.ts
+++ b/component-library/src/app/pages/request-form/request-form.component.ts
@@ -99,7 +99,6 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
       }
     ],
     size: 'small',
-    disabled: false,
     error: true
   };
 
@@ -288,7 +287,7 @@ export class RequestFormComponent implements OnInit, AfterViewInit {
 
     this.form.addControl(
       this.referencesTextAreaConfig.id,
-      new FormControl('', Validators.required)
+      new FormControl('', null)
     );
 
     this.form.addControl(


### PR DESCRIPTION
**Why are these changes introduced?**
* Related story #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/932997))

**What is this pull request doing?**
* Fixing issues with control value accessors within the radio component.
* Updates radio template
* Lint

**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)

** File names and hierarchies are in keeping with our norms:
* Interfaces start with 'I' followed by a capital letter and camel case (IInterfaceExample) and are descriptive
* Subjects are suffixed with 'Subj' (ex: thisIsAnExampleSubj)
* Subscriptions are suffixed with 'Sub' (ex: thisIsAnExampleSub)
* Observables ere suffixed with 'Obs$' (ex: thisIsAnExampleObs$)
* Class and variable names are camel case
* Class names should start with a capital letter (i.e. ExampleClass)
* Variable names should start with a lower case letter (i.e thisIsAnExampleVariable)
* All caps and underscores are used for exported constants (THIS_IS_A_CONSTANT)
* Names are all spelled correctly
* ngOnInit and constructor is removed when not used
* ':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?

**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.