### PR TITLE
Input Documentation Enhancement

### DIFF
--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -44,7 +44,7 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     size: 'small',
     type: 'text',
     required: false,
-    label: 'Label text',
+    label: 'Label Text',
     desc: 'Description line of text',
     errorMessages: []
   };
@@ -249,17 +249,20 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
   errorState = 'None';
   currentConfigId = this.inputConfig.id;
 
-  setInputType(value: any) {
+  setInputType(value: string) {
     this.inputConfig = {
       ...this.inputConfig,
+      label: value == 'password' ? 'Password' : 'Label Text',
       type: value == 'password' ? 'password' : 'text'
     };
     this.inputConfigSingle = {
       ...this.inputConfigSingle,
+      label: value == 'password' ? 'Password' : 'Label Text',
       type: value == 'password' ? 'password' : 'text'
     };
     this.inputConfigMulti = {
       ...this.inputConfigMulti,
+      label: value == 'password' ? 'Password' : 'Label Text',
       type: value == 'password' ? 'password' : 'text'
     };
 


### PR DESCRIPTION
Why are these changes introduced?
- Related story [934584](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/934584)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-input-doc-enhance/en/input-documentation)

What is this pull request doing?

- The password field Label read 'Password' when type password is chosen

Reviewer checklist:

1. Go to [qa page](https://d1whfh0luwluq8.cloudfront.net/qa-input-doc-enhance/en/input-documentation)
2. Click password, verify label & typescript config has changed.