### PR TITLE
Input Documentation Enhancement #2

### DIFF
--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.html
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.html
@@ -27,7 +27,14 @@
   </div>
   <ng-container toggles>
     <ng-container *ngFor="let toggle of toggles">
-      <ircc-cl-lib-radio-input [config]="toggle"></ircc-cl-lib-radio-input>
+      <ng-container
+        *ngIf="
+          (inputConfig.type === 'password' && toggle.id !== 'placeholder') ||
+          inputConfig.type !== 'password'
+        "
+      >
+        <ircc-cl-lib-radio-input [config]="toggle"></ircc-cl-lib-radio-input>
+      </ng-container>
     </ng-container>
     <ng-container *ngFor="let checkbox of checkboxes">
       <ircc-cl-lib-checkbox [config]="checkbox"></ircc-cl-lib-checkbox>

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -30,7 +30,7 @@ import { TranslateService } from '@app/share/templates/parent-template.module';
 })
 export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
   altLangLink = 'input';
-  formInput = new FormGroup({});
+  formInput: FormGroup = new FormGroup({});
   state: boolean = false;
 
   constructor(
@@ -252,6 +252,12 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
   currentConfigId = this.inputConfig.id;
 
   setInputType(value: string) {
+    // If set type to password, automatically select placeholder to False
+    if (value == 'password')
+      this.formInput.patchValue({
+        placeholder: 'False'
+      });
+
     this.inputConfig = {
       ...this.inputConfig,
       label:

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -74,6 +74,8 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     ]
   };
 
+  inputConfigRequired: boolean = false;
+
   toggles: IRadioInputComponentConfig[] = [
     {
       id: 'size',
@@ -252,17 +254,26 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
   setInputType(value: string) {
     this.inputConfig = {
       ...this.inputConfig,
-      label: value == 'password' ? 'Password' : 'Label Text',
+      label:
+        value == 'password'
+          ? this.parseRequiredLabel('Password', this.inputConfigRequired)
+          : this.parseRequiredLabel('Label Text', this.inputConfigRequired),
       type: value == 'password' ? 'password' : 'text'
     };
     this.inputConfigSingle = {
       ...this.inputConfigSingle,
-      label: value == 'password' ? 'Password' : 'Label Text',
+      label:
+        value == 'password'
+          ? this.parseRequiredLabel('Password', this.inputConfigRequired)
+          : this.parseRequiredLabel('Label Text', this.inputConfigRequired),
       type: value == 'password' ? 'password' : 'text'
     };
     this.inputConfigMulti = {
       ...this.inputConfigMulti,
-      label: value == 'password' ? 'Password' : 'Label Text',
+      label:
+        value == 'password'
+          ? this.parseRequiredLabel('Password', this.inputConfigRequired)
+          : this.parseRequiredLabel('Label Text', this.inputConfigRequired),
       type: value == 'password' ? 'password' : 'text'
     };
 
@@ -326,6 +337,8 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
         this.toggleDisabled(value['state']);
         this.state = value['state'];
       }
+      if (value['required'])
+        this.inputConfigRequired = value['required'] === 'True';
       this.parseToggleConfig(value);
       this.parseCodeViewConfig();
     });
@@ -341,7 +354,11 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
           ...this.inputConfigSingle,
           size: value['size'].toLowerCase(),
           hint: value['hint'] === 'True' ? 'Hint text' : undefined,
-          required: value['required'] === 'True',
+          required: this.inputConfigRequired,
+          label: this.parseRequiredLabel(
+            this.inputConfigSingle.label as string,
+            this.inputConfigRequired
+          ),
           desc:
             value['desc'] === 'True' ? 'Description line of text' : undefined,
           placeholder:
@@ -353,7 +370,11 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
           ...this.inputConfigMulti,
           size: value['size'].toLowerCase(),
           hint: value['hint'] === 'True' ? 'Hint text' : undefined,
-          required: value['required'] === 'True',
+          required: this.inputConfigRequired,
+          label: this.parseRequiredLabel(
+            this.inputConfigMulti.label as string,
+            this.inputConfigRequired
+          ),
           desc:
             value['desc'] === 'True' ? 'Description line of text' : undefined,
           placeholder:
@@ -365,7 +386,11 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
           ...this.inputConfig,
           size: value['size'].toLowerCase(),
           hint: value['hint'] === 'True' ? 'Hint text' : undefined,
-          required: value['required'] === 'True',
+          required: this.inputConfigRequired,
+          label: this.parseRequiredLabel(
+            this.inputConfig.label as string,
+            this.inputConfigRequired
+          ),
           desc:
             value['desc'] === 'True' ? 'Description line of text' : undefined,
           placeholder:
@@ -478,5 +503,25 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
           this.inputConfigCodeView
         )}`;
     }
+  }
+
+  private parseRequiredLabel(
+    label: string,
+    required: string | boolean
+  ): string {
+    const requiredLabel = ' (required)';
+    if (
+      (required === 'True' || required === true) &&
+      !label.includes(requiredLabel)
+    ) {
+      label += requiredLabel;
+    }
+    if (
+      (required === 'False' || required === false) &&
+      label.endsWith(requiredLabel)
+    ) {
+      label = label.substring(0, label.length - requiredLabel.length);
+    }
+    return label;
   }
 }


### PR DESCRIPTION
Why are these changes introduced?
- Related story [934584](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/934584)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-input-doc-enhance/en/input-documentation)

What is this pull request doing?

- Add required to label text for both basic and password input
- Hide placeholder config when on password tab

Reviewer checklist:

1. Go to [qa page](https://d1whfh0luwluq8.cloudfront.net/qa-input-doc-enhance/en/input-documentation)
2. Click required, verify **(required)** is added to label
3. Click password, verify **(required)** stays on label
4. Verify placeholder config is hidden