### PR TITLE
Autocomplete: Various mismatch with figma and some functionality refactoring.

### DIFF
--- a/component-library/component-lib/src/lib/form-components/autocomplete/autocomplete.component.ts
+++ b/component-library/component-lib/src/lib/form-components/autocomplete/autocomplete.component.ts
@@ -165,6 +165,11 @@ export class AutoCompleteComponent
     setTimeout(() => {
       this.showSuggestions = event;
     }, timeoutTime);
+
+    // Set 1st option as active when on focus
+    if (this.flyout.options.length > 0) {
+      this.flyout.options[0].active = true;
+    }
   }
 
   isSelected(event: any) {

--- a/component-library/component-lib/src/lib/form-components/input/input.component.ts
+++ b/component-library/component-lib/src/lib/form-components/input/input.component.ts
@@ -138,6 +138,7 @@ export class InputComponent
       color: 'var(--neutral-text)'
     }
   };
+  buttonAutoCompleteClearClicked: boolean = false;
 
   constructor(
     public standAloneFunctions: StandAloneFunctions,
@@ -244,7 +245,13 @@ export class InputComponent
   onTouchedLabel() {
     this.touched = true;
     this.getAriaErrorText();
-    this.focusEvent.emit(false);
+    setTimeout(() => {
+      // Do not emit blur event after clicking clear button
+      if (!this.buttonAutoCompleteClearClicked) {
+        this.focusEvent.emit(false);
+      }
+      this.buttonAutoCompleteClearClicked = false;
+    }, 100);
   }
 
   onFocus() {
@@ -327,6 +334,7 @@ export class InputComponent
   }
 
   public clearvalue() {
+    this.buttonAutoCompleteClearClicked = true;
     this.config.formGroup.controls[this.config.id].setValue('');
     this.focusEvent.emit(true);
   }

--- a/component-library/component-lib/src/lib/shared/flyout/flyout.component.ts
+++ b/component-library/component-lib/src/lib/shared/flyout/flyout.component.ts
@@ -155,6 +155,16 @@ export class FlyoutComponent implements OnInit {
       : this.isSelected.emit(null);
   }
 
+  @HostListener('mouseenter')
+  onHover() {
+    // Remove default active state for 1st option when user hover on flyout
+    if (
+      this.config.options.length > 0 &&
+      this.config.options[0].active === true
+    )
+      this.config.options[0].active = false;
+  }
+
   //takes in the active index from HostListeners and sets the config option to active state which triggers styling
   highlightIndex(el_id: any) {
     if (el_id) {

--- a/component-library/src/app/pages/autocomplete-documentation/autocomplete-documentation.component.ts
+++ b/component-library/src/app/pages/autocomplete-documentation/autocomplete-documentation.component.ts
@@ -30,7 +30,7 @@ export class AutocompleteDocumentationComponent
   currentLanguage: string = '';
   altLangLink = 'autocomplete';
   form: FormGroup = new FormGroup({});
-  form_interactive_button = new FormGroup({});
+  form_interactive_button: FormGroup = new FormGroup({});
 
   testArrays = TestArrays;
 
@@ -273,6 +273,13 @@ export class AutocompleteDocumentationComponent
           new FormControl(toggle.options[0].value)
         );
       }
+    });
+
+    // Set initial values for config toggles
+    this.form_interactive_button.patchValue({
+      hint: 'False',
+      error: 'False',
+      description: 'False'
     });
 
     this.form_interactive_button

--- a/core-library/component-styling/input-component/_input-component.scss
+++ b/core-library/component-styling/input-component/_input-component.scss
@@ -112,6 +112,7 @@
       transform: translate(0%, -50%);
       justify-self: flex-end;
       align-self: flex-end;
+      z-index: 999;
     }
 
     button:disabled {


### PR DESCRIPTION
Why are these changes introduced?
- Related story [938496](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/938496)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-autocomplete-fix/en/autocomplete-documentation)

What is this pull request doing?

- Match initial config for interactive demo with [Figma](https://www.figma.com/file/TPwx1HcbXRCZeIDePI4Y4N/Documentation-Site?type=design&node-id=4596-148445&mode=design&t=79BXgMmTyiyPaPcw-0)
- Highlight 1st option when autocomplete get focus
- Keep flyout visible when user clear input

Reviewer checklist:

1. Go to [qa page](https://d1whfh0luwluq8.cloudfront.net/qa-autocomplete-fix/en/autocomplete-documentation)
2. Check if initial config match figma
3. Click input field, check if 1st option is highlighted
4. Input random string then click clear button, check if option flyout is still visible.