### PR TITLE
Autocomplete demo: fix description initial state #2

### DIFF
--- a/component-library/src/app/pages/autocomplete-documentation/autocomplete-documentation.component.ts
+++ b/component-library/src/app/pages/autocomplete-documentation/autocomplete-documentation.component.ts
@@ -279,7 +279,7 @@ export class AutocompleteDocumentationComponent
     this.form_interactive_button.patchValue({
       hint: 'False',
       error: 'False',
-      description: 'False'
+      desc: 'False'
     });
 
     this.form_interactive_button


### PR DESCRIPTION
Why are these changes introduced?
- Related story [938496](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/938496)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-autocomplete-fix/en/autocomplete-documentation)

What is this pull request doing?

- Match initial config for interactive demo with [Figma](https://www.figma.com/file/TPwx1HcbXRCZeIDePI4Y4N/Documentation-Site?type=design&node-id=4596-148445&mode=design&t=79BXgMmTyiyPaPcw-0), fix description toggle

Reviewer checklist:

1. Go to [qa page](https://d1whfh0luwluq8.cloudfront.net/qa-autocomplete-fix/en/autocomplete-documentation)
2. Check if initial config match figma