### PR TITLE
Input Documentation Enhancement #3

### DIFF
--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.html
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.html
@@ -10,19 +10,8 @@
     class="input-container"
     #input
   >
-    <ng-container [ngSwitch]="errorState">
-      <ircc-cl-lib-input
-        *ngSwitchDefault
-        [config]="inputConfig"
-      ></ircc-cl-lib-input>
-      <ircc-cl-lib-input
-        *ngSwitchCase="'Single'"
-        [config]="inputConfigSingle"
-      ></ircc-cl-lib-input>
-      <ircc-cl-lib-input
-        *ngSwitchCase="'Multiple'"
-        [config]="inputConfigMulti"
-      ></ircc-cl-lib-input>
+    <ng-container>
+      <ircc-cl-lib-input [config]="inputConfig"></ircc-cl-lib-input>
     </ng-container>
   </div>
   <ng-container toggles>

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -344,12 +344,31 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
         this.determineErrorState(value, this.formInput, this.inputConfig.id);
         break;
       case 'state':
+        this.toggleDisabled(this.inputConfig.id, value);
         break;
       default:
         break;
     }
   }
 
+  /**
+   * Toggle disabled state of input
+   */
+  private toggleDisabled(currentConfigId: string, disabled: boolean) {
+    const inputControl: AbstractControl | null =
+      this.formInput.get(currentConfigId);
+    if (
+      (disabled && inputControl?.disabled) ||
+      (!disabled && inputControl?.enabled)
+    )
+      return;
+
+    if (disabled) {
+      inputControl?.disable();
+    } else {
+      inputControl?.enable();
+    }
+  }
   determineErrorState(value: string, formGroup: FormGroup, formID: string) {
     let errorArray: string[] = [];
     switch (value) {

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -331,7 +331,7 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
         this.inputConfig = {
           ...this.inputConfig,
           label: this.parseRequiredLabel(
-            'Label Text',
+            this.inputConfig.label as string,
             this.inputConfigRequired
           ),
           required: value === 'True'

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -231,6 +231,8 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     ]
   };
 
+  errorState = 'None';
+
   setInputType(value: string) {
     // If set type to password, automatically select placeholder to False
     if (value == 'password')
@@ -246,6 +248,7 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
           : this.parseRequiredLabel('Label Text', this.inputConfigRequired),
       type: value == 'password' ? 'password' : 'text'
     };
+    this.parseCodeViewConfig(this.errorState);
   }
 
   listOfConfigItems = [
@@ -335,6 +338,7 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
         };
         break;
       case 'error':
+        this.errorState = value;
         this.determineErrorState(value, this.formInput, this.inputConfig.id);
         break;
       case 'state':
@@ -343,6 +347,8 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
       default:
         break;
     }
+
+    this.parseCodeViewConfig(this.errorState);
   }
 
   /**
@@ -379,7 +385,6 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
         this.setErrors(formGroup, formID, errorArray);
         break;
     }
-    this.parseCodeViewConfig(value);
   }
 
   setErrors(formGroup: FormGroup, formID: string, errorKeys: string[]) {

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -46,31 +46,10 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     required: false,
     label: 'Label Text',
     desc: 'Description line of text',
-    errorMessages: []
-  };
-
-  inputConfigSingle: IInputComponentConfig = {
-    ...this.inputConfig,
-    id: 'input_single',
-    required: true,
-    errorMessages: [
-      { key: 'required', errorLOV: this.translate.instant('ERROR.singleError') }
-    ]
-  };
-
-  inputConfigMulti: IInputComponentConfig = {
-    ...this.inputConfig,
-    id: 'input_multi',
-    errorMessages: [
-      { key: 'email', errorLOV: this.translate.instant('ERROR.singleError') },
-      {
-        key: 'email',
-        errorLOV: this.translate.instant('ERROR.additionalError')
-      },
-      {
-        key: 'maxlength',
-        errorLOV: this.translate.instant('ERROR.additionalError')
-      }
+    errorMessages:[
+      { key: 'required', errorLOV: this.translate.instant('ERROR.singleError') },
+      { key: 'email', errorLOV: this.translate.instant('ERROR.additionalError') },
+      { key: 'email2', errorLOV: this.translate.instant('ERROR.additionalError') }
     ]
   };
 
@@ -248,8 +227,6 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     ]
   };
 
-  errorState = 'None';
-  currentConfigId = this.inputConfig.id;
 
   setInputType(value: string) {
     // If set type to password, automatically select placeholder to False
@@ -266,43 +243,14 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
           : this.parseRequiredLabel('Label Text', this.inputConfigRequired),
       type: value == 'password' ? 'password' : 'text'
     };
-    this.inputConfigSingle = {
-      ...this.inputConfigSingle,
-      label:
-        value == 'password'
-          ? this.parseRequiredLabel('Password', this.inputConfigRequired)
-          : this.parseRequiredLabel('Label Text', this.inputConfigRequired),
-      type: value == 'password' ? 'password' : 'text'
-    };
-    this.inputConfigMulti = {
-      ...this.inputConfigMulti,
-      label:
-        value == 'password'
-          ? this.parseRequiredLabel('Password', this.inputConfigRequired)
-          : this.parseRequiredLabel('Label Text', this.inputConfigRequired),
-      type: value == 'password' ? 'password' : 'text'
-    };
-
-    this.parseCodeViewConfig();
   }
+
+  listOfConfigItems = ['size', 'required', 'label', 'desc', 'hint', 'error', 'state']
 
   ngOnInit() {
     this.lang.setAltLangLink(this.altLangLink);
 
     this.formInput.addControl(this.inputConfig.id, new FormControl());
-    // Two more form controls, one for each combination of validators
-    this.formInput.addControl(
-      this.inputConfig.id + '_single',
-      new FormControl('', [Validators.required])
-    );
-    this.formInput.addControl(
-      this.inputConfig.id + '_multi',
-      new FormControl('', [
-        Validators.required,
-        Validators.maxLength(3),
-        Validators.email
-      ])
-    );
 
     this.toggles.forEach((toggle) => {
       if (toggle.options && toggle.options[1].text) {
@@ -337,179 +285,100 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
       error: 'None'
     });
 
-    this.formInput.valueChanges.subscribe((value: any) => {
-      if (value['error'] !== this.errorState) this.toggleErrors(value['error']);
-      if (value['state'] !== undefined) {
-        this.toggleDisabled(value['state']);
-        this.state = value['state'];
-      }
-      if (value['required'])
-        this.inputConfigRequired = value['required'] === 'True';
-      this.parseToggleConfig(value);
-      this.parseCodeViewConfig();
-    });
+    this.listOfConfigItems.forEach((configItem) => {
+      this.formInput.get(configItem)?.valueChanges.subscribe((value : any) => {
+        this.parseConfigSingleCheckbox(configItem, value)
+      });
+    })
+
   }
 
-  /**
-   * Return mapping of input config from form values
-   */
-  private parseToggleConfig(value: any) {
-    switch (this.errorState) {
-      case 'Single':
-        this.inputConfigSingle = {
-          ...this.inputConfigSingle,
-          size: value['size'].toLowerCase(),
-          hint: value['hint'] === 'True' ? 'Hint text' : undefined,
-          required: this.inputConfigRequired,
-          label: this.parseRequiredLabel(
-            this.inputConfigSingle.label as string,
-            this.inputConfigRequired
-          ),
-          desc:
-            value['desc'] === 'True' ? 'Description line of text' : undefined,
-          placeholder:
-            value['placeholder'] === 'True' ? 'Placeholder text' : undefined
-        };
-        break;
-      case 'Multiple':
-        this.inputConfigMulti = {
-          ...this.inputConfigMulti,
-          size: value['size'].toLowerCase(),
-          hint: value['hint'] === 'True' ? 'Hint text' : undefined,
-          required: this.inputConfigRequired,
-          label: this.parseRequiredLabel(
-            this.inputConfigMulti.label as string,
-            this.inputConfigRequired
-          ),
-          desc:
-            value['desc'] === 'True' ? 'Description line of text' : undefined,
-          placeholder:
-            value['placeholder'] === 'True' ? 'Placeholder text' : undefined
-        };
-        break;
-      default:
+  private parseConfigSingleCheckbox (type : string, value : any) {
+    switch (type) {
+      case 'size':
         this.inputConfig = {
           ...this.inputConfig,
-          size: value['size'].toLowerCase(),
-          hint: value['hint'] === 'True' ? 'Hint text' : undefined,
-          required: this.inputConfigRequired,
-          label: this.parseRequiredLabel(
-            this.inputConfig.label as string,
-            this.inputConfigRequired
-          ),
-          desc:
-            value['desc'] === 'True' ? 'Description line of text' : undefined,
-          placeholder:
-            value['placeholder'] === 'True' ? 'Placeholder text' : undefined
+          size: value.toLowerCase(),
         };
+        break;
+      case 'required':
+        this.inputConfig = {
+          ...this.inputConfig,
+          required: value === 'True',
+        };
+        break;
+      case 'label':
+        this.inputConfig = {
+          ...this.inputConfig,
+          label: value === 'True' ? 'Label Text' : undefined,
+
+        };
+        break;
+      case 'desc':
+        this.inputConfig = {
+          ...this.inputConfig,
+          desc: value === 'True' ? 'Description line of text' : undefined,
+        };
+        break;
+      case 'hint':
+        this.inputConfig = {
+          ...this.inputConfig,
+          hint: value === 'True' ? 'Hint Text' : undefined,
+        };
+        break;
+      case 'error':
+        this.determineErrorState(value, this.formInput, this.inputConfig.id)
+        break;
+      case 'state':
+        console.log("State", value)
+        // if(value !== undefined) {
+        //   console.log("Disable")
+        //   this.toggleDisabled(value, this.inputConfig.id, this.formInput);
+        // }
+        break;
+      default: 
+        console.log("Hit default case")
     }
   }
 
-  /**
-   * Set input field as touched, toggle error states of input
-   */
-  private toggleErrors(error: string) {
-    if (!this.formInput.get(this.currentConfigId)?.touched && error !== 'None')
-      this.formInput.get(this.currentConfigId)?.markAsTouched();
+  
 
-    this.errorState = error;
-    switch (error) {
+  determineErrorState(value: string, formGroup: FormGroup, formID: string) {
+    let errorArray: string[] = [];
+    switch (value) {
+      case 'Single':
+        errorArray = ['required']
+        console.log("single Error")
+        // errorArray.push(errors[0]);
+        this.setErrors(formGroup, formID, errorArray)
+        break;
+      case 'Multiple':
+        console.log("Mulit Error")
+        errorArray = ['required', 'email', 'email2']
+        this.setErrors(formGroup, formID, errorArray)
+        break;
       case 'None':
-        this.currentConfigId = this.inputConfig.id;
-        this.inputConfigCodeView.errorMessages = undefined;
-        break;
-      case 'Single':
-        this.currentConfigId = this.inputConfigSingle.id;
-        if (!this.formInput.get(this.currentConfigId)?.touched)
-          this.formInput.get(this.currentConfigId)?.markAsTouched();
-        this.inputConfigCodeView.errorMessages =
-          this.inputConfigSingle.errorMessages;
-        break;
-      case 'Multiple':
-        this.currentConfigId = this.inputConfigMulti.id;
-        this.formInput.get(this.inputConfigMulti.id)?.setValue('test');
-        if (!this.formInput.get(this.currentConfigId)?.touched)
-          this.formInput.get(this.currentConfigId)?.markAsTouched();
-        this.inputConfigCodeView.errorMessages =
-          this.inputConfigMulti.errorMessages;
+        console.log("No Error")
+        errorArray = []
+        this.setErrors(formGroup, formID, errorArray)
         break;
     }
-    this.parseCodeViewConfig();
   }
 
-  /**
-   * Toggle disabled state of input
-   */
-  private toggleDisabled(disabled: boolean) {
-    const inputControl: AbstractControl | null = this.formInput.get(
-      this.currentConfigId
-    );
-    if (
-      (disabled && inputControl?.disabled) ||
-      (!disabled && inputControl?.enabled)
-    )
-      return;
-
-    if (disabled) {
-      inputControl?.disable();
+  setErrors(formGroup: FormGroup, formID: string, errorKeys: string[]) {
+    let errorVals = {};
+    if (errorKeys.length === 0) {
+      formGroup.get(formID)?.setErrors(null);
     } else {
-      inputControl?.enable();
+      errorKeys.forEach(error => {
+        errorVals[error] = true
+      });
+      formGroup.get(formID)?.setErrors(errorVals);
+      formGroup.get(formID)?.markAsTouched();
     }
+    console.log('for errors:', formGroup.get(formID)?.errors)
   }
 
-  private parseCodeViewConfig() {
-    const index = this.codeViewConfig?.tab?.findIndex((t) => t.id === 'ts');
-    if (-1 == index || !index) return;
-    // New Method - Using Pointer manipulation
-    const tab = this.codeViewConfig?.tab?.find((t) => t.id === 'ts');
-    switch (this.errorState) {
-      case 'Single':
-        this.inputConfigCodeView = {
-          ...this.inputConfigCodeView,
-          size: this.inputConfigSingle.size,
-          type: this.inputConfigSingle.type,
-          required: this.inputConfigSingle.required,
-          label: this.inputConfigSingle.label,
-          desc: this.inputConfigSingle.desc,
-          hint: this.inputConfigSingle.hint,
-          placeholder: this.inputConfigSingle.placeholder
-        };
-        break;
-      case 'Multiple':
-        this.inputConfigCodeView = {
-          ...this.inputConfigCodeView,
-          size: this.inputConfigMulti.size,
-          type: this.inputConfigMulti.type,
-          required: this.inputConfigMulti.required,
-          label: this.inputConfigMulti.label,
-          desc: this.inputConfigMulti.desc,
-          hint: this.inputConfigMulti.hint,
-          placeholder: this.inputConfigMulti.placeholder
-        };
-        break;
-      default:
-        this.inputConfigCodeView = {
-          ...this.inputConfigCodeView,
-          size: this.inputConfig.size,
-          type: this.inputConfig.type,
-          required: this.inputConfig.required,
-          label: this.inputConfig.label,
-          desc: this.inputConfig.desc,
-          hint: this.inputConfig.hint,
-          placeholder: this.inputConfig.placeholder
-        };
-        break;
-    }
-
-    if (tab) {
-      tab.value =
-        "import { IInputComponentConfig } from 'ircc-ds-angular-component-library';\r" +
-        "import { FormGroup } from '@angular/forms';\n\n" +
-        `inputConfig: IInputComponentConfig = ${stringify(
-          this.inputConfigCodeView
-        )}`;
-    }
-  }
 
   private parseRequiredLabel(
     label: string,

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -46,10 +46,19 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     required: false,
     label: 'Label Text',
     desc: 'Description line of text',
-    errorMessages:[
-      { key: 'required', errorLOV: this.translate.instant('ERROR.singleError') },
-      { key: 'email', errorLOV: this.translate.instant('ERROR.additionalError') },
-      { key: 'email2', errorLOV: this.translate.instant('ERROR.additionalError') }
+    errorMessages: [
+      {
+        key: 'required',
+        errorLOV: 'ERROR.singleError'
+      },
+      {
+        key: 'email',
+        errorLOV: 'ERROR.additionalError'
+      },
+      {
+        key: 'email2',
+        errorLOV: 'ERROR.additionalError'
+      }
     ]
   };
 
@@ -227,7 +236,6 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     ]
   };
 
-
   setInputType(value: string) {
     // If set type to password, automatically select placeholder to False
     if (value == 'password')
@@ -245,7 +253,15 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     };
   }
 
-  listOfConfigItems = ['size', 'required', 'label', 'desc', 'hint', 'error', 'state']
+  listOfConfigItems = [
+    'size',
+    'required',
+    'label',
+    'desc',
+    'hint',
+    'error',
+    'state'
+  ];
 
   ngOnInit() {
     this.lang.setAltLangLink(this.altLangLink);
@@ -286,99 +302,151 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     });
 
     this.listOfConfigItems.forEach((configItem) => {
-      this.formInput.get(configItem)?.valueChanges.subscribe((value : any) => {
-        this.parseConfigSingleCheckbox(configItem, value)
+      this.formInput.get(configItem)?.valueChanges.subscribe((value: any) => {
+        this.parseConfigSingleCheckbox(configItem, value);
       });
-    })
-
+    });
   }
 
-  private parseConfigSingleCheckbox (type : string, value : any) {
+  private parseConfigSingleCheckbox(type: string, value: any) {
     switch (type) {
       case 'size':
         this.inputConfig = {
           ...this.inputConfig,
-          size: value.toLowerCase(),
+          size: value.toLowerCase()
         };
         break;
       case 'required':
         this.inputConfig = {
           ...this.inputConfig,
-          required: value === 'True',
+          required: value === 'True'
         };
         break;
       case 'label':
         this.inputConfig = {
           ...this.inputConfig,
-          label: value === 'True' ? 'Label Text' : undefined,
-
+          label: value === 'True' ? 'Label Text' : undefined
         };
         break;
       case 'desc':
         this.inputConfig = {
           ...this.inputConfig,
-          desc: value === 'True' ? 'Description line of text' : undefined,
+          desc: value === 'True' ? 'Description line of text' : undefined
         };
         break;
       case 'hint':
         this.inputConfig = {
           ...this.inputConfig,
-          hint: value === 'True' ? 'Hint Text' : undefined,
+          hint: value === 'True' ? 'Hint Text' : undefined
         };
         break;
       case 'error':
-        this.determineErrorState(value, this.formInput, this.inputConfig.id)
+        this.determineErrorState(value, this.formInput, this.inputConfig.id);
         break;
       case 'state':
-        console.log("State", value)
-        // if(value !== undefined) {
-        //   console.log("Disable")
-        //   this.toggleDisabled(value, this.inputConfig.id, this.formInput);
-        // }
         break;
-      default: 
-        console.log("Hit default case")
+      default:
+        break;
     }
   }
-
-  
 
   determineErrorState(value: string, formGroup: FormGroup, formID: string) {
     let errorArray: string[] = [];
     switch (value) {
       case 'Single':
-        errorArray = ['required']
-        console.log("single Error")
-        // errorArray.push(errors[0]);
-        this.setErrors(formGroup, formID, errorArray)
+        errorArray = ['required'];
+        this.setErrors(formGroup, formID, errorArray);
         break;
       case 'Multiple':
-        console.log("Mulit Error")
-        errorArray = ['required', 'email', 'email2']
-        this.setErrors(formGroup, formID, errorArray)
+        errorArray = ['required', 'email', 'email2'];
+        this.setErrors(formGroup, formID, errorArray);
         break;
       case 'None':
-        console.log("No Error")
-        errorArray = []
-        this.setErrors(formGroup, formID, errorArray)
+        errorArray = [];
+        this.setErrors(formGroup, formID, errorArray);
         break;
     }
+    this.parseCodeViewConfig(value);
   }
 
   setErrors(formGroup: FormGroup, formID: string, errorKeys: string[]) {
+    // eslint-disable-next-line
     let errorVals = {};
     if (errorKeys.length === 0) {
       formGroup.get(formID)?.setErrors(null);
     } else {
-      errorKeys.forEach(error => {
-        errorVals[error] = true
+      errorKeys.forEach((error) => {
+        errorVals[error] = true;
       });
       formGroup.get(formID)?.setErrors(errorVals);
       formGroup.get(formID)?.markAsTouched();
     }
-    console.log('for errors:', formGroup.get(formID)?.errors)
   }
 
+  private parseCodeViewConfig(errorState: string) {
+    const index = this.codeViewConfig?.tab?.findIndex((t) => t.id === 'ts');
+    if (-1 == index || !index) return;
+    // New Method - Using Pointer manipulation
+    const tab = this.codeViewConfig?.tab?.find((t) => t.id === 'ts');
+    this.inputConfigCodeView = {
+      ...this.inputConfigCodeView,
+      size: this.inputConfig.size,
+      type: this.inputConfig.type,
+      required: this.inputConfig.required,
+      label: this.inputConfig.label,
+      desc: this.inputConfig.desc,
+      hint: this.inputConfig.hint,
+      placeholder: this.inputConfig.placeholder
+    };
+
+    switch (errorState) {
+      case 'Single':
+        this.inputConfigCodeView = {
+          ...this.inputConfigCodeView,
+          errorMessages: [
+            {
+              key: 'required',
+              errorLOV: 'ERROR.singleError'
+            }
+          ]
+        };
+        break;
+      case 'Multiple':
+        this.inputConfigCodeView = {
+          ...this.inputConfigCodeView,
+          errorMessages: [
+            {
+              key: 'required',
+              errorLOV: 'ERROR.singleError'
+            },
+            {
+              key: 'email',
+              errorLOV: 'ERROR.additionalError'
+            },
+            {
+              key: 'email2',
+              errorLOV: 'ERROR.additionalError'
+            }
+          ]
+        };
+        break;
+      default:
+        this.inputConfigCodeView = {
+          ...this.inputConfigCodeView,
+          errorMessages: []
+        };
+        break;
+    }
+
+    if (tab) {
+      tab.value =
+        "import { IInputComponentConfig } from 'ircc-ds-angular-component-library';\r" +
+        "import { FormGroup } from '@angular/forms';\n\n" +
+        `inputConfig: IInputComponentConfig = ${stringify(
+          this.inputConfigCodeView
+        )}`;
+    }
+  }
 
   private parseRequiredLabel(
     label: string,

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -256,6 +256,7 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     'required',
     'label',
     'desc',
+    'placeholder',
     'hint',
     'error',
     'state'
@@ -329,6 +330,12 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
         this.inputConfig = {
           ...this.inputConfig,
           desc: value === 'True' ? 'Description line of text' : undefined
+        };
+        break;
+      case 'placeholder':
+        this.inputConfig = {
+          ...this.inputConfig,
+          placeholder: value === 'True' ? 'Placeholder text' : undefined
         };
         break;
       case 'hint':

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -8,12 +8,7 @@ import {
   IRadioInputComponentConfig,
   ITabNavConfig
 } from 'ircc-ds-angular-component-library';
-import {
-  AbstractControl,
-  FormControl,
-  FormGroup,
-  Validators
-} from '@angular/forms';
+import { AbstractControl, FormControl, FormGroup } from '@angular/forms';
 import {
   ICodeViewerConfig,
   stringify

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -317,15 +317,14 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
         };
         break;
       case 'required':
+        this.inputConfigRequired = value === 'True';
         this.inputConfig = {
           ...this.inputConfig,
+          label: this.parseRequiredLabel(
+            'Label Text',
+            this.inputConfigRequired
+          ),
           required: value === 'True'
-        };
-        break;
-      case 'label':
-        this.inputConfig = {
-          ...this.inputConfig,
-          label: value === 'True' ? 'Label Text' : undefined
         };
         break;
       case 'desc':

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -44,15 +44,15 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
     errorMessages: [
       {
         key: 'required',
-        errorLOV: 'ERROR.singleError'
+        errorLOV: this.translate.instant('ERROR.singleError')
       },
       {
         key: 'email',
-        errorLOV: 'ERROR.additionalError'
+        errorLOV: this.translate.instant('ERROR.additionalError')
       },
       {
         key: 'email2',
-        errorLOV: 'ERROR.additionalError'
+        errorLOV: this.translate.instant('ERROR.additionalError')
       }
     ]
   };
@@ -442,7 +442,7 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
           errorMessages: [
             {
               key: 'required',
-              errorLOV: 'ERROR.singleError'
+              errorLOV: this.translate.instant('ERROR.singleError')
             }
           ]
         };
@@ -453,15 +453,15 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
           errorMessages: [
             {
               key: 'required',
-              errorLOV: 'ERROR.singleError'
+              errorLOV: this.translate.instant('ERROR.singleError')
             },
             {
               key: 'email',
-              errorLOV: 'ERROR.additionalError'
+              errorLOV: this.translate.instant('ERROR.additionalError')
             },
             {
               key: 'email2',
-              errorLOV: 'ERROR.additionalError'
+              errorLOV: this.translate.instant('ERROR.additionalError')
             }
           ]
         };

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -292,6 +292,17 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
         }
       });
 
+    // Watch input change & overwrite error state on the fly
+    this.formInput
+      .get(this.inputConfig.id)
+      ?.valueChanges.subscribe((changes) => {
+        this.determineErrorState(
+          this.errorState,
+          this.formInput,
+          this.inputConfig.id
+        );
+      });
+
     this.formInput.patchValue({
       size: 'Small',
       hint: 'False',

--- a/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-doc-code.component.ts
@@ -406,8 +406,7 @@ export class InputDocCodeComponent implements OnInit, TranslatedPageComponent {
   }
 
   setErrors(formGroup: FormGroup, formID: string, errorKeys: string[]) {
-    // eslint-disable-next-line
-    let errorVals = {};
+    const errorVals = {};
     if (errorKeys.length === 0) {
       formGroup.get(formID)?.setErrors(null);
     } else {


### PR DESCRIPTION
Why are these changes introduced?
- Related story [934584](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/934584)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-input-doc-code-fix/en/input-documentation)

What is this pull request doing?

- Fix when user selects Multiple error option, a input "test" is populated in the input field for both password and basic inputs
- Fix When the single option is selected, entering text into the input field removes the error however, when selecting multiple error option, text in the input field does not remove the 3 error lines
- Consolidate 3 configs into one for error state management

Reviewer checklist:

1. Go to [qa page](https://d1whfh0luwluq8.cloudfront.net/qa-input-doc-code-fix/en/input-documentation)
2. Click Error -> Multiple
3. Verify no text shows up in input