### PR TITLE
Add role to indicator component

### DIFF
--- a/component-library/component-lib/src/lib/shared/indicator/indicator.component.html
+++ b/component-library/component-lib/src/lib/shared/indicator/indicator.component.html
@@ -6,7 +6,7 @@
     (config.label ?? '')
   "
   [tabindex]="config.tabIndex"
-  [attr.role]="config.ariaLabel ? 'group' : null"
+  role="group"
 >
   <div
     *ngIf="config.type === 'text' || config.type === 'number'"

--- a/component-library/component-lib/src/lib/shared/indicator/indicator.component.html
+++ b/component-library/component-lib/src/lib/shared/indicator/indicator.component.html
@@ -1,11 +1,12 @@
 <div
   [ngClass]="['indicator-container', config.size ?? '']"
-  [attr.aria-label]="
+    [attr.aria-label]="
     (config.ariaLabel ?? 'Indicator.Heading' | translate) +
     ' ' +
     (config.label ?? '')
   "
   [tabindex]="config.tabIndex"
+  [attr.role]="config.ariaLabel ? 'group' : null"
 >
   <div
     *ngIf="config.type === 'text' || config.type === 'number'"


### PR DESCRIPTION
**Why are these changes introduced?**
* Related story #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/914321))

**What is this pull request doing?**
* Adds a role to the indicator component container to fix accessibility issue 'Elements must only use the allowed aria attributes'

TEST
* Build and run the project locally
* Navigate to Michael's QA page
* Open the indicator component
* Access dev tools - Axe Dev Tools - scan the page
* The 'Elements must only use the allowed aria attributes' should no longer be found in the scan
* Aria role for reference: #([URL](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/group_role))

![Screenshot 2023-09-13 at 1 43 59 PM](https://github.com/IRCC-ca/ds-sdc-dev/assets/130089656/a32e50d5-6483-4b1b-853d-e74d88df3892)
