### PR TITLE
fix date picker title

### DIFF
--- a/component-library/src/assets/locales/en.json
+++ b/component-library/src/assets/locales/en.json
@@ -561,7 +561,7 @@
 		"LabelText1": "Label text"
 	},
 	"DatePicker": {
-		"MainTitle": "Date picker",
+		"MainTitle": "Date Picker",
 		"Title": "DatePicker-doc",
 		"Intro": "The date picker component allows users to input a specific year, month and/or day.",
 		"DesignGuideLines": {


### PR DESCRIPTION
Small translation fix to update the date picker title to 'Date Picker' rather than Date picker per spec.