### PR TITLE
Bug: Error icon disappears when toggling placeholder

### DIFF
--- a/component-library/component-lib/src/lib/form-components/autocomplete/autocomplete.component.html
+++ b/component-library/component-lib/src/lib/form-components/autocomplete/autocomplete.component.html
@@ -2,6 +2,7 @@
   <ircc-cl-lib-input
     [attr.size]="config.size"
     [config]="inputComponent"
+    type="autocomplete"
     (focusEvent)="onFocus($event)"
   ></ircc-cl-lib-input>
 

--- a/component-library/component-lib/src/lib/form-components/error/error.component.html
+++ b/component-library/component-lib/src/lib/form-components/error/error.component.html
@@ -1,18 +1,13 @@
 <div
-  class="errorComponent"
-  class="{{ config?.size }}"
+  class="{{ config?.size }} errorComponent"
   id="{{ config?.id }}"
   [ngClass]="{ errorContainer: config?.id?.endsWith('error0') }"
 >
-  <i
-    *ngIf="config?.id?.endsWith('error0')"
-    [ngClass]="
-      config?.icon !== undefined
-        ? config?.icon?.class
-        : 'fa-light fa-circle-exclamation'
-    "
+  <ircc-cl-lib-icon
+    *ngIf="config?.id?.endsWith('error0') && iconConfig"
+    [config]="iconConfig"
     class="errorIcon"
-  ></i>
+  ></ircc-cl-lib-icon>
   <p
     [ngClass]="{ additionalError: !config?.id?.endsWith('error0') }"
     class="errorText"

--- a/component-library/component-lib/src/lib/form-components/error/error.component.ts
+++ b/component-library/component-lib/src/lib/form-components/error/error.component.ts
@@ -6,6 +6,7 @@ import {
   SimpleChanges
 } from '@angular/core';
 import { DSSizes } from '../../../shared/constants/jl-components.constants';
+import { IIconConfig } from '../../shared/icon/icon.component';
 
 export interface IErrorIconConfig {
   class: string; // Fontawesome icon class
@@ -29,6 +30,7 @@ export class ErrorComponent implements OnInit, OnChanges {
   @Input() errorLOV?: string;
   @Input() icon?: IErrorIconConfig;
   @Input() size?: keyof typeof DSSizes;
+  iconConfig?: IIconConfig;
 
   constructor() {}
   ngOnInit() {
@@ -51,6 +53,12 @@ export class ErrorComponent implements OnInit, OnChanges {
       if (this.errorLOV) this.config.errorLOV = this.errorLOV;
       if (this.icon) this.config.icon = this.icon;
       if (this.size) this.config.size = this.size;
+
+      this.iconConfig = {
+        FA_keywords:
+          this.config.icon?.class ?? 'fa-light fa-circle-exclamation',
+        size: this.config.size
+      };
     }
   }
 }

--- a/component-library/component-lib/src/lib/form-components/input/input.component.html
+++ b/component-library/component-lib/src/lib/form-components/input/input.component.html
@@ -110,7 +110,7 @@
               <ircc-cl-lib-error
                 [id]="errors.id"
                 [errorLOV]="errors.errorLOV"
-                [attr.size]="config.size"
+                [size]="config.size"
               ></ircc-cl-lib-error>
             </div>
           </ng-container>

--- a/component-library/component-lib/src/shared/functions/stand-alone.functions.ts
+++ b/component-library/component-lib/src/shared/functions/stand-alone.functions.ts
@@ -71,6 +71,25 @@ export class StandAloneFunctions {
   }
 
   /**
+   * Given a form group & form control id, set errors & mark as touch on specific form controls
+   * @param formGroup
+   * @param formID ID of form control
+   * @param errorKeys
+   */
+  setFormErrors(formGroup: FormGroup, formID: string, errorKeys: string[]) {
+    const errorVals = {};
+    if (errorKeys.length === 0) {
+      formGroup.get(formID)?.setErrors(null);
+    } else {
+      errorKeys.forEach((error) => {
+        errorVals[error] = true;
+      });
+      formGroup.get(formID)?.setErrors(errorVals);
+      formGroup.get(formID)?.markAsTouched();
+    }
+  }
+
+  /**
    * Create a label config - for use inside form input components
    * @param formGroup
    * @param id

--- a/component-library/src/app/pages/autocomplete-documentation/autocomplete-documentation.component.ts
+++ b/component-library/src/app/pages/autocomplete-documentation/autocomplete-documentation.component.ts
@@ -228,9 +228,15 @@ export class AutocompleteDocumentationComponent
   ngOnInit() {
     this.lang.setAltLangLink(this.altLangLink);
     this.config.formGroup.addControl(this.config.id, new FormControl());
-    if (!this.form.get(this.config.id)?.touched) {
-      this.form.get(this.config.id)?.markAsTouched();
-    }
+
+    this.config.formGroup.valueChanges.subscribe((changes) => {
+      // Stop user input from clearing error messages if error is toggled to True
+      if (this.form_interactive_button.get('error')?.value === 'True') {
+        this.standalone.setFormErrors(this.config.formGroup, this.config.id, [
+          'required'
+        ]);
+      }
+    });
 
     this.form_interactive_button.valueChanges.subscribe((change) => {
       this.autocompleteCodeView = {

--- a/component-library/src/app/pages/autocomplete-documentation/autocomplete-documentation.component.ts
+++ b/component-library/src/app/pages/autocomplete-documentation/autocomplete-documentation.component.ts
@@ -8,7 +8,8 @@ import {
   IBannerConfig,
   ICheckBoxComponentConfig,
   IRadioInputComponentConfig,
-  ITabNavConfig
+  ITabNavConfig,
+  StandAloneFunctions
 } from 'ircc-ds-angular-component-library';
 import { TranslatedPageComponent } from '../translated-page-component';
 
@@ -218,17 +219,15 @@ export class AutocompleteDocumentationComponent
   constructor(
     private translate: TranslateService,
     private lang: LangSwitchService,
-    private slugify: SlugifyPipe
+    private slugify: SlugifyPipe,
+    private standalone: StandAloneFunctions
   ) {
     this.currentLanguage = translate.currentLang;
   }
 
   ngOnInit() {
     this.lang.setAltLangLink(this.altLangLink);
-    this.config.formGroup.addControl(
-      this.config.id,
-      new FormControl(null, Validators.required)
-    );
+    this.config.formGroup.addControl(this.config.id, new FormControl());
     if (!this.form.get(this.config.id)?.touched) {
       this.form.get(this.config.id)?.markAsTouched();
     }
@@ -331,15 +330,9 @@ export class AutocompleteDocumentationComponent
       .get('error')
       ?.valueChanges.subscribe((change: string) => {
         if (change === 'True') {
-          this.config.formGroup.removeControl(this.config.id);
-          this.config.formGroup.addControl(
-            this.config.id,
-            new FormControl(null, Validators.required)
-          );
-
-          if (!this.form.get(this.config.id)?.touched) {
-            this.form.get(this.config.id)?.markAsTouched();
-          }
+          this.standalone.setFormErrors(this.config.formGroup, this.config.id, [
+            'required'
+          ]);
           this.config = {
             ...this.config,
             errorMessages: [
@@ -350,12 +343,11 @@ export class AutocompleteDocumentationComponent
             ]
           };
         } else {
-          this.config.formGroup.removeControl(this.config.id);
-          this.config.formGroup.addControl(this.config.id, new FormControl());
-
-          if (!this.form.get(this.config.id)?.touched) {
-            this.form.get(this.config.id)?.markAsUntouched();
-          }
+          this.standalone.setFormErrors(
+            this.config.formGroup,
+            this.config.id,
+            []
+          );
           this.config = {
             ...this.config,
             errorMessages: undefined

--- a/core-library/component-styling/error/_error.scss
+++ b/core-library/component-styling/error/_error.scss
@@ -28,6 +28,11 @@ $selectors: "ircc-cl-lib-error";
   .errorIcon {
     height: 16px;
     width: 16px;
+
+    svg {
+      height: 16px;
+      width: 16px;
+    }
     @include device.in-tablet-layout {
       margin-top: 2px;
   }
@@ -59,6 +64,11 @@ $selectors: "ircc-cl-lib-error";
   .errorIcon {
     height: 20px;
     width: 20px;
+
+    svg {
+      height: 20px;
+      width: 20px;
+    }
   }
 
   .errorText {


### PR DESCRIPTION
Why are these changes introduced?
- Related bug [943716](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/943716)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-autocomplete-fix/en/autocomplete-documentation)

What is this pull request doing?

- Refactor autocomplete demo to use standalone set error instead of swap out form controls
- Fix error icon disappears when toggling placeholder
- Refactor lib-error icon to use ircc-cl-lib-icon component

Reviewer checklist:

1. Go to [qa page](https://d1whfh0luwluq8.cloudfront.net/qa-autocomplete-fix/en/autocomplete-documentation)
2. Verify no error message on initial state
3. Toggle error to **True**
4. Input anything in text input, toggle placeholder to **True**
5. Verify error icon does not disappear