### PR TITLE
Autocomplete fix: clicking anywhere after clearing out the input does not remove the flyout dropdown option

### DIFF
--- a/component-library/component-lib/src/lib/form-components/input/input.component.html
+++ b/component-library/component-lib/src/lib/form-components/input/input.component.html
@@ -34,6 +34,7 @@
                 ? 'input-password-field'
                 : 'input-text-field'
             "
+            #inputEl
             [type]="typeControl"
             [id]="config.id"
             [formControlName]="config.id"

--- a/component-library/component-lib/src/lib/form-components/input/input.component.ts
+++ b/component-library/component-lib/src/lib/form-components/input/input.component.ts
@@ -2,12 +2,15 @@ import {
   AfterContentChecked,
   ChangeDetectorRef,
   Component,
+  ElementRef,
   EventEmitter,
   forwardRef,
   Input,
   OnChanges,
   OnInit,
-  Output
+  Output,
+  Renderer2,
+  ViewChild
 } from '@angular/core';
 import {
   AbstractControl,
@@ -112,6 +115,8 @@ export class InputComponent
   @Input() errorMessages?: IErrorPairs[];
   @Output() focusEvent = new EventEmitter();
 
+  @ViewChild('inputEl') inputEl?: ElementRef;
+
   disabled = false;
   focusState = false;
   showPassword?: boolean;
@@ -145,7 +150,8 @@ export class InputComponent
   constructor(
     public standAloneFunctions: StandAloneFunctions,
     private translate: TranslateService,
-    private changeDetectorRef: ChangeDetectorRef
+    private changeDetectorRef: ChangeDetectorRef,
+    private renderer: Renderer2
   ) {
     //set config from individual options, if present
     if (this.formGroup !== this.formGroupEmpty) {
@@ -365,6 +371,7 @@ export class InputComponent
   public clearvalue() {
     this.buttonAutoCompleteClearClicked = true;
     this.config.formGroup.controls[this.config.id].setValue('');
+    this.renderer.selectRootElement(this.inputEl?.nativeElement).focus();
     this.focusEvent.emit(true);
   }
 

--- a/component-library/component-lib/src/lib/form-components/input/input.component.ts
+++ b/component-library/component-lib/src/lib/form-components/input/input.component.ts
@@ -341,7 +341,11 @@ export class InputComponent
       this.errorIds = [];
     }
 
-    if (this.config.type) this.typeControl = this.config.type;
+    if (this.config.type === InputTypes.autocomplete) {
+      this.typeControl = InputTypes.text;
+    } else if (this.config.type) {
+      this.typeControl = this.config.type;
+    }
 
     this.showPassword =
       this.config.type === InputTypes.password &&


### PR DESCRIPTION
Why are these changes introduced?
- Related task [938496](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/938496)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-password-fix/en/input-documentation)

What is this pull request doing?

- Fix input focus state disappear when user click clear button
- Fix autocomplete input field style