### PR TITLE
Icon Button has too many empty button fix

### DIFF
--- a/component-library/component-lib/src/lib/shared/icon-button/icon-button.component.html
+++ b/component-library/component-lib/src/lib/shared/icon-button/icon-button.component.html
@@ -11,6 +11,7 @@
     <ircc-cl-lib-icon
       [config]="{ FA_keywords: config.icon?.class }"
       [style.color]="config.icon?.color"
+      [ariaLabel]="config.icon?.class"
     ></ircc-cl-lib-icon>
   </span>
 </button>

--- a/component-library/component-lib/src/lib/shared/navigation/navigation.component.html
+++ b/component-library/component-lib/src/lib/shared/navigation/navigation.component.html
@@ -21,7 +21,9 @@
       (click)="clickIconLeading(config.id + '_icon_leading')"
       [attr.size]="config.size"
     ></ircc-cl-lib-icon>
-    <h3>{{ config?.label || '' | translate }}</h3>
+    <ng-container *ngIf="config?.label">
+      <h3>{{ config?.label || '' | translate }}</h3>
+    </ng-container>
     <ircc-cl-lib-icon
       [id]="config.id + '_icon_trailing'"
       class="icon-trailing"


### PR DESCRIPTION
**Why are these changes introduced?**
* Related story [950504](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/950504)
* [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-icon-button-empty/en/overview)

**What is this pull request doing?**
* Fixes the bug discovered using the "Empty Heading" bug in Waves in relation to the icon-button component.