### PR TITLE
Input doc page: add right side nav

### DIFF
--- a/component-library/src/app/pages/input-documentation/input-documentation.component.html
+++ b/component-library/src/app/pages/input-documentation/input-documentation.component.html
@@ -634,3 +634,7 @@
     <p>{{ 'General.ComingSoon' | translate }}</p>
   </section>
 </div>
+<app-side-nav
+  class="right-nav col-12 col-lg-3 col-xl-2"
+  [rightNavLOVs]="rightNavData"
+></app-side-nav>

--- a/component-library/src/app/pages/input-documentation/input-documentation.component.ts
+++ b/component-library/src/app/pages/input-documentation/input-documentation.component.ts
@@ -157,6 +157,21 @@ export class InputDocumentationComponent implements OnInit {
     'General.AccessibilityContentItemMax'
   ];
 
+  rightNavData: string[] = [
+    // list of all right nav items
+    'Input.Title',
+    'General.InteractiveDemo',
+    'General.TypesHeading',
+    'General.ConfigurationsHeading',
+    'General.DesignGuidelinesHeading',
+    'General.AnatomyHeading',
+    'General.SpecsHeading',
+    'General.ContentGuidelinesHeading',
+    'General.FigmaHeading',
+    'General.AccessibilityHeading',
+    'General.ResearchHeading'
+  ];
+
   constructor(
     private translate: TranslateService,
     private lang: LangSwitchService,


### PR DESCRIPTION
Why are these changes introduced?
- Related task [945724](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/d006c866-0d87-4b32-93cb-f457d4ec2c0b/_workitems/edit/945724)
- [QA Link](https://d1whfh0luwluq8.cloudfront.net/qa-autocomplete-fix/en/autocomplete-documentation)

What is this pull request doing?

- Add right side nav to input doc page