### PR TITLE
Textarea announce Max char limit reached on each keypress

### DIFF
--- a/component-library/component-lib/src/lib/form-components/textarea/textarea.component.html
+++ b/component-library/component-lib/src/lib/form-components/textarea/textarea.component.html
@@ -51,9 +51,10 @@
           </p>
           <span
             class="sr-only"
-            *ngIf="isEventActive"
-            >{{ testVar }}</span
+            aria-live="polite"
+            [innerHTML]="announceMaxCharaterLimitReached"
           >
+          </span>
         </div>
       </div>
 

--- a/component-library/component-lib/src/lib/form-components/textarea/textarea.component.html
+++ b/component-library/component-lib/src/lib/form-components/textarea/textarea.component.html
@@ -49,6 +49,11 @@
           >
             {{ textareaInput.value.length }}/{{ config.charLimit }}
           </p>
+          <span
+            class="sr-only"
+            *ngIf="isEventActive"
+            >{{ testVar }}</span
+          >
         </div>
       </div>
 

--- a/component-library/component-lib/src/lib/form-components/textarea/textarea.component.ts
+++ b/component-library/component-lib/src/lib/form-components/textarea/textarea.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, Input, OnInit } from '@angular/core';
+import { Component, forwardRef, HostListener, Input, OnInit } from '@angular/core';
 import {
   ControlValueAccessor,
   FormControlStatus,
@@ -93,6 +93,10 @@ export class TextareaComponent implements ControlValueAccessor, OnInit {
     parentID: ''
   };
   textAreaAriaLabel = '';
+
+  isEventActive = false;
+
+  testVar = ''
 
   constructor(
     public standAloneFunctions: StandAloneFunctions,
@@ -205,23 +209,28 @@ export class TextareaComponent implements ControlValueAccessor, OnInit {
     let currLang = this.translate.currentLang;
     if (this.config?.charLimit) {
       if (this.config?.charLimit == currCharCount) {
+        console.log("MAX LIMIT CONDITION")
         this.charLimitStatus = 'maxLimit';
         currLang === 'en' || currLang === 'en-US'
           ? (this.currentCharacterStatusAria = MAX_CHAR_LIMIT_EN)
           : (this.currentCharacterStatusAria = MAX_CHAR_LIMIT_FR);
         this.announceCharStatusChangeAria = true;
+        this.isEventActive = true;
       } else if (Number(this.config?.charLimit) - currCharCount == 15) {
         this.charLimitStatus = 'warningLimit';
         currLang === 'en' || currLang === 'en-US'
           ? (this.currentCharacterStatusAria = WARNING_CHAR_LIMIT_EN)
           : (this.currentCharacterStatusAria = WARNING_CHAR_LIMIT_FR);
         this.announceCharStatusChangeAria = true;
+        this.isEventActive = false;
       } else if (Number(this.config?.charLimit) - currCharCount < 15) {
         this.charLimitStatus = 'warningLimit';
         this.currentCharacterStatusAria = '';
+        this.isEventActive = false;
       } else {
         this.charLimitStatus = '';
         this.currentCharacterStatusAria = '';
+        this.isEventActive = false;
       }
     }
   }
@@ -234,6 +243,24 @@ export class TextareaComponent implements ControlValueAccessor, OnInit {
     } else {
       this.charLength = 0;
     }
+  }
+
+
+  @HostListener('window:keypress', ['$event'])
+  onKeyPress(event: KeyboardEvent) {
+    if (this.isEventActive) {
+      console.log("EVENT ACTIVE")
+      this.testVar = 'MAX LIMIT REACHED TESTING'
+    }
+    if (this.charLimitStatus !== 'maxLimit') {
+      console.log("EVENT NOT ACTIVE")
+      this.removeKeyPressEvent();
+    }
+  }
+
+  removeKeyPressEvent() {
+    // Set isEventActive to false to disable the event
+    this.isEventActive = false;
   }
 
   formatCharacterUsedString(currentLength: number): string {

--- a/component-library/component-lib/src/lib/form-components/textarea/textarea.component.ts
+++ b/component-library/component-lib/src/lib/form-components/textarea/textarea.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, HostListener, Input, OnInit } from '@angular/core';
+import { Component, ElementRef, forwardRef, HostListener, Input, OnInit, Renderer2, ViewChild } from '@angular/core';
 import {
   ControlValueAccessor,
   FormControlStatus,
@@ -92,11 +92,8 @@ export class TextareaComponent implements ControlValueAccessor, OnInit {
     formGroup: this.config.formGroup,
     parentID: ''
   };
-  textAreaAriaLabel = '';
-
   isEventActive = false;
-
-  testVar = ''
+  announceMaxCharaterLimitReached = ''
 
   constructor(
     public standAloneFunctions: StandAloneFunctions,
@@ -175,6 +172,10 @@ export class TextareaComponent implements ControlValueAccessor, OnInit {
           this.toggleDisabledState();
         }
       });
+
+    this.translate.currentLang === 'en' || this.translate.currentLang === 'en-US'
+      ? (this.announceMaxCharaterLimitReached = MAX_CHAR_LIMIT_EN)
+      : (this.announceMaxCharaterLimitReached = MAX_CHAR_LIMIT_FR);
   }
 
   toggleDisabledState() {
@@ -209,7 +210,6 @@ export class TextareaComponent implements ControlValueAccessor, OnInit {
     let currLang = this.translate.currentLang;
     if (this.config?.charLimit) {
       if (this.config?.charLimit == currCharCount) {
-        console.log("MAX LIMIT CONDITION")
         this.charLimitStatus = 'maxLimit';
         currLang === 'en' || currLang === 'en-US'
           ? (this.currentCharacterStatusAria = MAX_CHAR_LIMIT_EN)
@@ -245,22 +245,22 @@ export class TextareaComponent implements ControlValueAccessor, OnInit {
     }
   }
 
-
+  //Keep announcing max char limit reached for each keypress made after max limit has reached
   @HostListener('window:keypress', ['$event'])
   onKeyPress(event: KeyboardEvent) {
     if (this.isEventActive) {
-      console.log("EVENT ACTIVE")
-      this.testVar = 'MAX LIMIT REACHED TESTING'
+      if(this.announceMaxCharaterLimitReached === MAX_CHAR_LIMIT_EN || this.announceMaxCharaterLimitReached === MAX_CHAR_LIMIT_FR) {
+        this.announceMaxCharaterLimitReached+='&nbsp;'
+      }
+      else {
+        this.translate.currentLang === 'en' || this.translate.currentLang === 'en-US'
+          ? (this.announceMaxCharaterLimitReached = MAX_CHAR_LIMIT_EN)
+          : (this.announceMaxCharaterLimitReached = MAX_CHAR_LIMIT_FR);
+      }
     }
     if (this.charLimitStatus !== 'maxLimit') {
-      console.log("EVENT NOT ACTIVE")
-      this.removeKeyPressEvent();
+      this.isEventActive = false;
     }
-  }
-
-  removeKeyPressEvent() {
-    // Set isEventActive to false to disable the event
-    this.isEventActive = false;
   }
 
   formatCharacterUsedString(currentLength: number): string {

--- a/core-library/component-styling/textarea/_textarea.scss
+++ b/core-library/component-styling/textarea/_textarea.scss
@@ -7,6 +7,7 @@
 @use "../../typography/typography" as typography;
 @use "../../tokens/text" as text;
 @use "sass:map";
+@use "../../util/accessibility" as a11y;
 
 @mixin selector {
   ircc-cl-lib-textarea#{template-const.$escape} {
@@ -105,6 +106,10 @@
         }
       }
     }
+  }
+
+  .sr-only {
+    @include a11y.sr-only;
   }
 
   @include at-resize(none);

--- a/core-library/component-styling/textarea/_textarea.scss
+++ b/core-library/component-styling/textarea/_textarea.scss
@@ -105,11 +105,11 @@
           }
         }
       }
-    }
-  }
 
-  .sr-only {
-    @include a11y.sr-only;
+      .sr-only {
+        @include a11y.sr-only;
+      }
+    }
   }
 
   @include at-resize(none);


### PR DESCRIPTION
**Why are these changes introduced?**
* Related story #([URL](https://alm-tfs.apps.ci.gc.ca/tfs/IRCC/Scrum/_workitems/edit/951962))
* Discussion between the story developer and the reviewer to clarify and confirm where needed

**What is this pull request doing?**
* Added keypress listener to listen to all keypresses once max limit has reached and announce max limit reached for each keypress after
* Added translation for respected variables

**Reviewer checklist:**
* Module structure is appropriate (when applicable)
* @Input()s are handled in keeping with established norms (i.e. a config and individual inputs for CL components)

** File names and hierarchies are in keeping with our norms:
* Interfaces start with 'I' followed by a capital letter and camel case (IInterfaceExample) and are descriptive
* Subjects are suffixed with 'Subj' (ex: thisIsAnExampleSubj)
* Subscriptions are suffixed with 'Sub' (ex: thisIsAnExampleSub)
* Observables ere suffixed with 'Obs$' (ex: thisIsAnExampleObs$)
* Class and variable names are camel case
* Class names should start with a capital letter (i.e. ExampleClass)
* Variable names should start with a lower case letter (i.e thisIsAnExampleVariable)
* All caps and underscores are used for exported constants (THIS_IS_A_CONSTANT)
* Names are all spelled correctly
* ngOnInit and constructor is removed when not used
* ':void' is removed from void functions
* Ensure the code contain appropriate media queries and accessibility elements
* Is the acceptance criteria met?

**Review component stylesheets:**
* New sheet is added to index.scss.
* New sheet includes @create and @selector(s) mixins.
* Selectors: Are classes leveraged as much as possible? Does the naming convention make sense and follow some sort of convention? (Nice to have: BEM naming applied)
* Is any styling repeated in the sheet? If yes can a mixin be leveraged instead?
* No !important tags are present in the page.
* All colors used are existing tokens. No mix-token mixin is leveraged unless creating a new token.
* Are the styles escaped using the template-const file.
* Avoid using element selectors for specificity where possible

**Token sheets:**
* All tokens are created using mix-token mixin.
* No layout styling is handled.
* Tokens are available globally at the project root.