### PR TITLE
add conditions to check to remove decrementing years and days from da…

### DIFF
--- a/component-library/component-lib/src/lib/form-components/date-picker/date-picker.component.ts
+++ b/component-library/component-lib/src/lib/form-components/date-picker/date-picker.component.ts
@@ -386,7 +386,9 @@ export class DatePickerComponent implements OnInit {
    * Used to set the language of year/day 'unknown' field when langauge changes
    */
   setYearDayLanguage() {
+    if (this.config.unknownDateToggle?.dayUnknown) 
     this.dropDownConfigs.day.options?.shift();
+    if (this.config.unknownDateToggle?.yearUnknown)
     this.dropDownConfigs.year.options?.shift();
     if (
       this.translate.currentLang === 'en' ||


### PR DESCRIPTION
* when unknown is not used in the datepicker config, the values for year and day are reducing whenever the language toggle is triggered.
* add conditional check in setYearsDayLanguage to only shift the values when unknown is being used